### PR TITLE
Add CPU/RAM history sparklines per process (#8)

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -32,6 +32,7 @@
   <script src="js/utils/format.js"></script>
   <script src="js/state.js"></script>
   <script src="js/components/group-header.js"></script>
+  <script src="js/components/sparkline.js"></script>
   <script src="js/components/process-table.js"></script>
   <script src="js/components/kill-button.js"></script>
   <script src="js/components/status-bar.js"></script>

--- a/renderer/js/components/process-table.js
+++ b/renderer/js/components/process-table.js
@@ -28,12 +28,35 @@ function renderProcessTable(processes) {
   ]);
 
   const rows = processes.map((proc) => {
+    const history = AppState.getHistory(proc.pid);
+    const cpuHistory = history.map((entry) => entry.cpu);
+    const ramHistory = history.map((entry) => entry.memKB);
+
+    const cpuColor = proc.cpu >= 50 ? 'var(--accent-red)' : proc.cpu >= 15 ? 'var(--accent-amber)' : 'var(--accent-green)';
+    const cpuFill = proc.cpu >= 50 ? 'rgba(247, 118, 142, 0.15)' : proc.cpu >= 15 ? 'rgba(224, 175, 104, 0.15)' : 'rgba(158, 206, 106, 0.15)';
+
+    const cpuSparkline = renderSparkline(cpuHistory, { stroke: cpuColor, fill: cpuFill });
+    cpuSparkline.addEventListener('click', (e) => { e.stopPropagation(); showSparklineDetail(proc.pid, 'cpu'); });
+
+    const ramSparkline = renderSparkline(ramHistory, { stroke: 'var(--accent-purple)', fill: 'rgba(187, 154, 247, 0.15)' });
+    ramSparkline.addEventListener('click', (e) => { e.stopPropagation(); showSparklineDetail(proc.pid, 'ram'); });
+
+    const cpuCell = h('td', { className: `col-cpu ${cpuClass(proc.cpu)}` }, [
+      h('span', { className: 'cell-value' }, formatCpu(proc.cpu)),
+      cpuSparkline,
+    ]);
+
+    const ramCell = h('td', { className: 'col-ram' }, [
+      h('span', { className: 'cell-value' }, formatBytes(proc.memKB)),
+      ramSparkline,
+    ]);
+
     const row = h('tr', { dataset: { pid: proc.pid } }, [
       h('td', { className: 'col-name', title: proc.name }, proc.name),
       h('td', { className: 'col-pid' }, proc.pid.toString()),
       h('td', { className: 'col-port' }, formatPort(proc.ports)),
-      h('td', { className: `col-cpu ${cpuClass(proc.cpu)}` }, formatCpu(proc.cpu)),
-      h('td', { className: 'col-ram' }, formatBytes(proc.memKB)),
+      cpuCell,
+      ramCell,
       h('td', { className: 'col-uptime' }, formatUptime(proc.started)),
       h('td', { className: 'col-action' }, [renderKillButton(proc.pid, proc.name)]),
     ]);

--- a/renderer/js/components/sparkline.js
+++ b/renderer/js/components/sparkline.js
@@ -1,0 +1,244 @@
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function svgEl(tag, attrs) {
+  const el = document.createElementNS(SVG_NS, tag);
+  if (attrs) {
+    for (const [key, value] of Object.entries(attrs)) {
+      if (key === 'style') {
+        el.setAttribute('style', value);
+      } else {
+        el.setAttribute(key, value);
+      }
+    }
+  }
+  return el;
+}
+
+/**
+ * Render a small inline sparkline SVG from an array of numeric values.
+ * @param {number[]} values - Data points to plot
+ * @param {object} opts
+ * @param {number} opts.width - SVG width (default 48)
+ * @param {number} opts.height - SVG height (default 16)
+ * @param {string} opts.stroke - Line color
+ * @param {string} opts.fill - Fill color (gradient bottom)
+ * @returns {SVGElement}
+ */
+function renderSparkline(values, opts = {}) {
+  const width = opts.width || 48;
+  const height = opts.height || 16;
+  const stroke = opts.stroke || 'var(--accent-blue)';
+  const fill = opts.fill || 'rgba(122, 162, 247, 0.15)';
+  const padding = 1;
+
+  const svg = svgEl('svg', {
+    width: width,
+    height: height,
+    viewBox: `0 0 ${width} ${height}`,
+    class: 'sparkline',
+  });
+
+  if (!values || values.length < 2) {
+    return svg;
+  }
+
+  const max = Math.max(...values, 1);
+  const min = 0;
+  const range = max - min || 1;
+  const plotW = width - padding * 2;
+  const plotH = height - padding * 2;
+
+  const points = values.map((v, i) => {
+    const x = padding + (i / (values.length - 1)) * plotW;
+    const y = padding + plotH - ((v - min) / range) * plotH;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+
+  const polyline = svgEl('polyline', {
+    points: points.join(' '),
+    'stroke-width': '1.2',
+    'stroke-linejoin': 'round',
+    'stroke-linecap': 'round',
+    style: `fill:none;stroke:${stroke}`,
+  });
+
+  // Fill area under the line
+  const firstX = padding;
+  const lastX = padding + plotW;
+  const bottom = height - padding;
+  const areaPoints = `${firstX},${bottom} ${points.join(' ')} ${lastX},${bottom}`;
+
+  const polygon = svgEl('polygon', {
+    points: areaPoints,
+    style: `fill:${fill};stroke:none`,
+  });
+
+  svg.appendChild(polygon);
+  svg.appendChild(polyline);
+
+  return svg;
+}
+
+/**
+ * Render a larger detail chart in a modal.
+ * @param {number} pid
+ * @param {'cpu'|'ram'} metric
+ */
+function showSparklineDetail(pid, metric) {
+  // Remove any existing sparkline modal
+  const existing = document.querySelector('.sparkline-modal');
+  if (existing) existing.remove();
+
+  const history = AppState.getHistory(pid);
+  if (!history || history.length < 2) return;
+
+  const values = history.map((entry) => (metric === 'cpu' ? entry.cpu : entry.memKB));
+  const isCpu = metric === 'cpu';
+
+  const stroke = isCpu ? 'var(--accent-amber)' : 'var(--accent-purple)';
+  const fill = isCpu ? 'rgba(224, 175, 104, 0.2)' : 'rgba(187, 154, 247, 0.2)';
+  const label = isCpu ? 'CPU %' : 'Memory';
+
+  // Create modal
+  const overlay = h('div', { className: 'modal sparkline-modal' });
+
+  const chartWidth = 420;
+  const chartHeight = 180;
+  const marginLeft = 45;
+  const marginBottom = 20;
+  const marginTop = 10;
+  const marginRight = 10;
+  const plotW = chartWidth - marginLeft - marginRight;
+  const plotH = chartHeight - marginTop - marginBottom;
+
+  const max = Math.max(...values, isCpu ? 100 : 1);
+  const min = 0;
+  const range = max - min || 1;
+
+  const svg = svgEl('svg', {
+    width: chartWidth,
+    height: chartHeight,
+    viewBox: `0 0 ${chartWidth} ${chartHeight}`,
+    class: 'sparkline-detail-chart',
+  });
+
+  // Grid lines and Y-axis labels
+  const gridSteps = 4;
+  for (let i = 0; i <= gridSteps; i++) {
+    const y = marginTop + (i / gridSteps) * plotH;
+    const val = max - (i / gridSteps) * range;
+
+    const line = svgEl('line', {
+      x1: marginLeft,
+      y1: y,
+      x2: chartWidth - marginRight,
+      y2: y,
+      'stroke-width': '0.5',
+      style: 'stroke:var(--border-color)',
+    });
+    svg.appendChild(line);
+
+    const text = svgEl('text', {
+      x: marginLeft - 6,
+      y: y + 3,
+      'font-size': '9',
+      'text-anchor': 'end',
+      style: 'fill:var(--text-muted);font-family:var(--font-mono)',
+    });
+    text.textContent = isCpu ? `${val.toFixed(0)}%` : formatBytes(val);
+    svg.appendChild(text);
+  }
+
+  // X-axis labels (time)
+  const totalSeconds = (values.length - 1) * 3;
+  const xLabels = [0, Math.floor(values.length / 2), values.length - 1];
+  for (const idx of xLabels) {
+    const x = marginLeft + (idx / (values.length - 1)) * plotW;
+    const secsAgo = (values.length - 1 - idx) * 3;
+    const text = svgEl('text', {
+      x: x,
+      y: chartHeight - 4,
+      'font-size': '9',
+      'text-anchor': 'middle',
+      style: 'fill:var(--text-muted);font-family:var(--font-mono)',
+    });
+    text.textContent = secsAgo === 0 ? 'now' : `-${secsAgo}s`;
+    svg.appendChild(text);
+  }
+
+  // Data line
+  const points = values.map((v, i) => {
+    const x = marginLeft + (i / (values.length - 1)) * plotW;
+    const y = marginTop + plotH - ((v - min) / range) * plotH;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+
+  // Fill
+  const firstX = marginLeft;
+  const lastX = marginLeft + plotW;
+  const bottomY = marginTop + plotH;
+  const areaPoints = `${firstX},${bottomY} ${points.join(' ')} ${lastX},${bottomY}`;
+  svg.appendChild(svgEl('polygon', { points: areaPoints, style: `fill:${fill};stroke:none` }));
+
+  // Line
+  svg.appendChild(
+    svgEl('polyline', {
+      points: points.join(' '),
+      'stroke-width': '1.5',
+      'stroke-linejoin': 'round',
+      'stroke-linecap': 'round',
+      style: `fill:none;stroke:${stroke}`,
+    })
+  );
+
+  // Current value dot
+  const lastPoint = values[values.length - 1];
+  const dotX = marginLeft + plotW;
+  const dotY = marginTop + plotH - ((lastPoint - min) / range) * plotH;
+  svg.appendChild(
+    svgEl('circle', {
+      cx: dotX.toFixed(1),
+      cy: dotY.toFixed(1),
+      r: '3',
+      style: `fill:${stroke}`,
+    })
+  );
+
+  // Build modal content
+  const currentVal = isCpu ? formatCpu(lastPoint) : formatBytes(lastPoint);
+  const maxVal = isCpu ? formatCpu(Math.max(...values)) : formatBytes(Math.max(...values));
+  const avgVal = values.reduce((a, b) => a + b, 0) / values.length;
+  const avgFormatted = isCpu ? formatCpu(avgVal) : formatBytes(avgVal);
+
+  const content = h('div', { className: 'modal-content sparkline-detail-content' }, [
+    h('div', { className: 'sparkline-detail-header' }, [
+      h('span', { className: 'sparkline-detail-label' }, `${label} — PID ${pid}`),
+      h('span', { className: 'sparkline-detail-stats' }, `Current: ${currentVal}  Avg: ${avgFormatted}  Peak: ${maxVal}`),
+    ]),
+    // SVG will be appended below
+    h('div', { className: 'sparkline-detail-footer' }, [
+      h('span', { className: 'sparkline-detail-samples' }, `${values.length} samples (${totalSeconds}s)`),
+    ]),
+  ]);
+
+  // Insert SVG before footer
+  content.insertBefore(svg, content.lastElementChild);
+
+  overlay.appendChild(content);
+
+  function closeModal() {
+    overlay.remove();
+    document.removeEventListener('keydown', onKey);
+  }
+
+  function onKey(e) {
+    if (e.key === 'Escape') closeModal();
+  }
+
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) closeModal();
+  });
+
+  document.addEventListener('keydown', onKey);
+  document.body.appendChild(overlay);
+}

--- a/renderer/js/state.js
+++ b/renderer/js/state.js
@@ -1,3 +1,5 @@
+const HISTORY_MAX = 60;
+
 const AppState = {
   groups: {},
   warnings: [],
@@ -8,14 +10,42 @@ const AppState = {
   sortDirection: 'desc',
   collapsedGroups: new Set(['system']),
   listeners: [],
+  history: new Map(),
 
   update(data) {
     if (!data) return;
+    this._recordHistory(data);
     this.groups = data.groups;
     this.warnings = data.warnings;
     this.lastUpdated = data.timestamp;
     this.totalProcesses = data.totalProcesses;
     this.notify();
+  },
+
+  _recordHistory(data) {
+    const activePids = new Set();
+    for (const group of Object.values(data.groups)) {
+      for (const proc of group.processes) {
+        activePids.add(proc.pid);
+        if (!this.history.has(proc.pid)) {
+          this.history.set(proc.pid, []);
+        }
+        const buf = this.history.get(proc.pid);
+        buf.push({ cpu: proc.cpu, memKB: proc.memKB || 0 });
+        if (buf.length > HISTORY_MAX) {
+          buf.shift();
+        }
+      }
+    }
+    for (const pid of this.history.keys()) {
+      if (!activePids.has(pid)) {
+        this.history.delete(pid);
+      }
+    }
+  },
+
+  getHistory(pid) {
+    return this.history.get(pid) || [];
   },
 
   setFilter(text) {

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -139,12 +139,12 @@
 }
 
 .process-table .col-cpu {
-  width: 65px;
+  width: 120px;
   text-align: right;
 }
 
 .process-table .col-ram {
-  width: 80px;
+  width: 135px;
   text-align: right;
 }
 
@@ -275,6 +275,75 @@
 
 .highlight-row {
   animation: highlightPulse 3s ease-out !important;
+}
+
+/* Sparklines */
+.sparkline {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 6px;
+  cursor: pointer;
+  opacity: 0.8;
+  transition: opacity var(--transition-speed);
+  flex-shrink: 0;
+}
+
+.sparkline:hover {
+  opacity: 1;
+}
+
+.col-cpu,
+.col-ram {
+  white-space: nowrap;
+}
+
+.cell-value {
+  display: inline-block;
+  min-width: 42px;
+  text-align: right;
+}
+
+/* Sparkline detail modal */
+.sparkline-modal .modal-content {
+  min-width: 460px;
+  padding: 16px 20px;
+  text-align: left;
+}
+
+.sparkline-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 12px;
+}
+
+.sparkline-detail-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.sparkline-detail-stats {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  white-space: pre;
+}
+
+.sparkline-detail-chart {
+  display: block;
+  margin: 0 auto;
+}
+
+.sparkline-detail-footer {
+  margin-top: 8px;
+  text-align: center;
+}
+
+.sparkline-detail-samples {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
 }
 
 @keyframes highlightPulse {


### PR DESCRIPTION
Track last 60 data points per PID and render inline SVG sparklines
next to CPU and RAM values. Click a sparkline to open a detail modal
with a larger chart showing grid, axes, and stats (current/avg/peak).

https://claude.ai/code/session_013AypanNHyz2knpaaojxVa5