### PR TITLE
Add batch kill actions: kill group, kill all on port, restart dev (#9)

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1,6 +1,6 @@
 const { ipcMain, shell, app } = require('electron');
 const { collectAll } = require('./poll-manager');
-const { kill } = require('./services/process-killer');
+const { kill, killMultiple } = require('./services/process-killer');
 const { collect: collectDetails, getExecutablePath } = require('./collectors/detail-collector');
 const { updateTooltip } = require('./tray-manager');
 const notifier = require('./services/notifier');
@@ -23,6 +23,10 @@ function registerIpcHandlers() {
 
   ipcMain.handle('kill-process', async (_event, pid) => {
     return kill(pid);
+  });
+
+  ipcMain.handle('kill-processes', async (_event, pids) => {
+    return killMultiple(pids);
   });
 
   ipcMain.handle('set-notifications-enabled', (_event, value) => {

--- a/main/preload.js
+++ b/main/preload.js
@@ -3,6 +3,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('api', {
   getProcesses: () => ipcRenderer.invoke('get-processes'),
   killProcess: (pid) => ipcRenderer.invoke('kill-process', pid),
+  killProcesses: (pids) => ipcRenderer.invoke('kill-processes', pids),
   setNotificationsEnabled: (value) => ipcRenderer.invoke('set-notifications-enabled', value),
   getNotificationsEnabled: () => ipcRenderer.invoke('get-notifications-enabled'),
   getProcessDetails: (pid) => ipcRenderer.invoke('get-process-details', pid),

--- a/main/services/process-killer.js
+++ b/main/services/process-killer.js
@@ -31,4 +31,24 @@ function kill(pid) {
   }
 }
 
-module.exports = { kill };
+function killMultiple(pids) {
+  if (!Array.isArray(pids) || pids.length === 0) {
+    return { success: false, error: 'No PIDs provided', results: [] };
+  }
+
+  const results = pids.map((pid) => ({
+    pid,
+    ...kill(pid),
+  }));
+
+  const failed = results.filter((r) => !r.success);
+  return {
+    success: failed.length === 0,
+    total: pids.length,
+    killed: pids.length - failed.length,
+    failed: failed.length,
+    results,
+  };
+}
+
+module.exports = { kill, killMultiple };

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -29,6 +29,16 @@
       </div>
     </div>
   </div>
+  <div id="batch-confirm-modal" class="modal hidden">
+    <div class="modal-content batch-confirm-content">
+      <p id="batch-confirm-title" class="batch-confirm-title"></p>
+      <div id="batch-confirm-list" class="batch-confirm-list"></div>
+      <div class="modal-actions">
+        <button id="batch-confirm-yes" class="btn btn-danger">Kill All</button>
+        <button id="batch-confirm-no" class="btn btn-secondary">Cancel</button>
+      </div>
+    </div>
+  </div>
   <script src="js/utils/dom.js"></script>
   <script src="js/utils/format.js"></script>
   <script src="js/state.js"></script>

--- a/renderer/js/components/context-menu.js
+++ b/renderer/js/components/context-menu.js
@@ -1,3 +1,15 @@
+function findProcessesOnPort(port) {
+  const results = [];
+  for (const group of Object.values(AppState.groups)) {
+    for (const proc of group.processes) {
+      if (proc.ports && proc.ports.includes(port)) {
+        results.push(proc);
+      }
+    }
+  }
+  return results;
+}
+
 let activeMenu = null;
 
 function showContextMenu(x, y, proc) {
@@ -24,6 +36,23 @@ function showContextMenu(x, y, proc) {
       icon: ':',
       action: () => navigator.clipboard.writeText(proc.ports.join(', ')),
     });
+
+    // "Kill all on port X" for each port this process listens on
+    for (const port of proc.ports) {
+      const procsOnPort = findProcessesOnPort(port);
+      items.push({
+        label: `Kill All on :${port}`,
+        icon: '\u00D7',
+        className: 'context-item-danger',
+        action: () => {
+          showBatchKillConfirm(
+            `Kill all ${procsOnPort.length} process(es) on port ${port}?`,
+            procsOnPort,
+            (pids) => window.api.killProcesses(pids)
+          );
+        },
+      });
+    }
   }
 
   items.push({ separator: true });

--- a/renderer/js/components/group-header.js
+++ b/renderer/js/components/group-header.js
@@ -8,11 +8,83 @@ function renderGroupHeader(group, isCollapsed) {
     h('span', {}, formatBytes(group.totalMemKB)),
   ]);
 
-  const header = h('div', { className: 'group-header' }, [toggle, icon, name, count, stats]);
+  const actionsBtn = h('button', { className: 'group-actions-btn', title: 'Group actions' }, '\u22EE');
+  actionsBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    showGroupActionsMenu(e.clientX, e.clientY, group);
+  });
+
+  const header = h('div', { className: 'group-header' }, [toggle, icon, name, count, stats, actionsBtn]);
 
   header.addEventListener('click', () => {
     AppState.toggleGroup(group.key);
   });
 
   return header;
+}
+
+function showGroupActionsMenu(x, y, group) {
+  hideContextMenu();
+
+  const items = [
+    {
+      label: `Kill All ${group.label}`,
+      icon: '\u00D7',
+      className: 'context-item-danger',
+      action: () => {
+        if (group.processes.length === 0) return;
+        showBatchKillConfirm(
+          `Kill all ${group.processes.length} ${group.label.toLowerCase()} process(es)?`,
+          group.processes,
+          (pids) => window.api.killProcesses(pids)
+        );
+      },
+    },
+  ];
+
+  // "Restart" option only for dev group — kills and notifies user to manually restart
+  if (group.key === 'dev') {
+    items.push({
+      label: 'Restart Dev Processes',
+      icon: '\u21BB',
+      className: 'context-item-danger',
+      action: () => {
+        if (group.processes.length === 0) return;
+        showBatchKillConfirm(
+          `Kill all ${group.processes.length} dev process(es)? You will need to restart them manually.`,
+          group.processes,
+          async (pids) => {
+            const result = await window.api.killProcesses(pids);
+            if (result.killed > 0) {
+              try {
+                new Notification('Localhost Dashboard', {
+                  body: `Killed ${result.killed} dev process(es). Restart them manually.`,
+                });
+              } catch { /* notifications may not be available */ }
+            }
+            return result;
+          }
+        );
+      },
+    });
+  }
+
+  // Build and show the menu using the shared context menu infrastructure
+  const menu = h('div', { className: 'context-menu' }, buildMenuItems(items));
+  document.body.appendChild(menu);
+  activeMenu = menu;
+
+  const rect = menu.getBoundingClientRect();
+  const winW = window.innerWidth;
+  const winH = window.innerHeight;
+  const left = (x + rect.width > winW) ? winW - rect.width - 4 : x;
+  const top = (y + rect.height > winH) ? winH - rect.height - 4 : y;
+  menu.style.left = `${Math.max(0, left)}px`;
+  menu.style.top = `${Math.max(0, top)}px`;
+
+  requestAnimationFrame(() => {
+    document.addEventListener('click', onCloseContextMenu, { once: true });
+    document.addEventListener('contextmenu', onCloseContextMenu, { once: true });
+    document.addEventListener('keydown', onEscapeContextMenu);
+  });
 }

--- a/renderer/js/components/kill-button.js
+++ b/renderer/js/components/kill-button.js
@@ -35,6 +35,70 @@ function showKillConfirm(pid, processName) {
   noBtn.addEventListener('click', cleanup, { once: true });
 }
 
+function showBatchKillConfirm(title, processes, onConfirm) {
+  const modal = document.getElementById('batch-confirm-modal');
+  const titleEl = document.getElementById('batch-confirm-title');
+  const listEl = document.getElementById('batch-confirm-list');
+  const yesBtn = document.getElementById('batch-confirm-yes');
+  const noBtn = document.getElementById('batch-confirm-no');
+
+  titleEl.textContent = title;
+  listEl.innerHTML = '';
+
+  for (const proc of processes) {
+    const row = h('div', { className: 'batch-confirm-item' }, [
+      h('span', { className: 'batch-confirm-name' }, proc.name),
+      h('span', { className: 'batch-confirm-pid' }, `PID ${proc.pid}`),
+      proc.ports && proc.ports.length > 0
+        ? h('span', { className: 'batch-confirm-port' }, `:${proc.ports.join(', :')}`)
+        : null,
+    ].filter(Boolean));
+    listEl.appendChild(row);
+  }
+
+  yesBtn.textContent = processes.length === 1 ? 'Kill' : `Kill All (${processes.length})`;
+  modal.classList.remove('hidden');
+
+  const cleanup = () => {
+    modal.classList.add('hidden');
+    yesBtn.replaceWith(yesBtn.cloneNode(true));
+    noBtn.replaceWith(noBtn.cloneNode(true));
+  };
+
+  const onEscape = (e) => {
+    if (e.key === 'Escape') cleanup();
+  };
+  document.addEventListener('keydown', onEscape);
+
+  const cleanupAll = () => {
+    cleanup();
+    document.removeEventListener('keydown', onEscape);
+  };
+
+  yesBtn.addEventListener('click', async () => {
+    cleanupAll();
+    try {
+      const pids = processes.map((p) => p.pid);
+      const result = await onConfirm(pids);
+      if (result && !result.success) {
+        const failedNames = result.results
+          .filter((r) => !r.success)
+          .map((r) => {
+            const proc = processes.find((p) => p.pid === r.pid);
+            return `${proc ? proc.name : 'PID ' + r.pid}: ${r.error}`;
+          });
+        if (failedNames.length > 0) {
+          showError(`Failed to kill ${failedNames.length} process(es):\n${failedNames.join('\n')}`);
+        }
+      }
+    } catch (err) {
+      showError(err.message || 'Unknown error');
+    }
+  }, { once: true });
+
+  noBtn.addEventListener('click', cleanupAll, { once: true });
+}
+
 function showError(msg) {
   const modal = document.getElementById('confirm-modal');
   const message = document.getElementById('confirm-message');

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -58,6 +58,31 @@
   color: var(--text-secondary);
 }
 
+.group-actions-btn {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 6px;
+  border-radius: 3px;
+  line-height: 1;
+  transition: all var(--transition-speed);
+  opacity: 0;
+  margin-left: 4px;
+  -webkit-app-region: no-drag;
+}
+
+.group-header:hover .group-actions-btn {
+  opacity: 1;
+}
+
+.group-actions-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--border-color);
+  background: var(--bg-hover);
+}
+
 .group-body {
   overflow: hidden;
   transition: max-height 0.3s ease;
@@ -837,4 +862,59 @@
   0%, 100% { transform: translateX(0); }
   25% { transform: translateX(-4px); }
   75% { transform: translateX(4px); }
+}
+
+/* ── Batch confirm dialog ────────────────────────────── */
+.batch-confirm-content {
+  min-width: 380px;
+  max-width: 480px;
+  text-align: left;
+}
+
+.batch-confirm-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 12px;
+}
+
+.batch-confirm-list {
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 16px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-primary);
+}
+
+.batch-confirm-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 10px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.batch-confirm-item:last-child {
+  border-bottom: none;
+}
+
+.batch-confirm-name {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.batch-confirm-pid {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.batch-confirm-port {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent-cyan);
+  margin-left: auto;
 }


### PR DESCRIPTION
Implements quick actions for common developer workflows:
- Kill Group: action button (⋮) on group headers to kill all processes in a category
- Kill All on Port: context menu option to terminate all processes on a specific port
- Restart Dev Processes: kills dev processes and notifies user to restart manually
- Batch confirmation dialog showing affected processes before execution

Closes #9

https://claude.ai/code/session_013K6MZpfvMYNSAqSSF56orr