### PR TITLE
Add port shortcuts, pinning, thresholds, export, and keybinds

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1,4 +1,6 @@
-const { ipcMain, shell, app } = require('electron');
+const { ipcMain, shell, app, dialog, BrowserWindow } = require('electron');
+const fs = require('fs');
+const path = require('path');
 const { collectAll } = require('./poll-manager');
 const { kill, killMultiple } = require('./services/process-killer');
 const { launchCommand } = require('./services/profile-runner');
@@ -56,6 +58,46 @@ function registerIpcHandlers() {
   // ── Profile IPC ──────────────────────────────────────────────
   ipcMain.handle('launch-service-command', (_event, { command, cwd }) => {
     return launchCommand(command, cwd);
+  });
+
+  // ── Open localhost URL in default browser ────────────────────
+  ipcMain.handle('open-url', async (_event, url) => {
+    // Only allow http(s) localhost URLs
+    try {
+      const u = new URL(url);
+      if (!/^https?:$/.test(u.protocol)) return { success: false, error: 'Only http(s) URLs allowed' };
+      const host = u.hostname;
+      if (host !== 'localhost' && host !== '127.0.0.1' && host !== '::1' && host !== '0.0.0.0') {
+        return { success: false, error: 'Only localhost URLs allowed' };
+      }
+      await shell.openExternal(u.toString());
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: err.message };
+    }
+  });
+
+  // ── Export current snapshot to JSON ──────────────────────────
+  ipcMain.handle('export-snapshot', async () => {
+    const data = await collectAll();
+    if (!data) return { success: false, error: 'No data available' };
+
+    const win = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const defaultName = `localhost-snapshot-${ts}.json`;
+    const res = await dialog.showSaveDialog(win, {
+      title: 'Export snapshot',
+      defaultPath: path.join(app.getPath('downloads'), defaultName),
+      filters: [{ name: 'JSON', extensions: ['json'] }],
+    });
+    if (res.canceled || !res.filePath) return { success: false, canceled: true };
+
+    try {
+      fs.writeFileSync(res.filePath, JSON.stringify(data, null, 2), 'utf8');
+      return { success: true, path: res.filePath };
+    } catch (err) {
+      return { success: false, error: err.message };
+    }
   });
 
   // ── Config IPC ───────────────────────────────────────────────

--- a/main/poll-manager.js
+++ b/main/poll-manager.js
@@ -3,7 +3,8 @@ const portCollector = require('./collectors/port-collector');
 const systemCollector = require('./collectors/system-collector');
 const dockerCollector = require('./collectors/docker-collector');
 const { classify, GROUP_META } = require('./services/classifier');
-const { detect } = require('./services/anomaly-detector');
+const { detect, detectThresholds } = require('./services/anomaly-detector');
+const config = require('./services/config');
 
 let busy = false;
 let dockerCacheCounter = 0;
@@ -75,8 +76,14 @@ async function collectAll() {
       });
     }
 
-    // Detect anomalies
+    // Detect anomalies (port conflicts + resource thresholds)
     const warnings = detect(merged);
+    const thresholdWarnings = detectThresholds(merged, {
+      cpuThreshold: config.get('cpuThreshold'),
+      memThresholdMB: config.get('memThresholdMB'),
+      sustainPolls: config.get('thresholdSustainPolls'),
+    });
+    warnings.push(...thresholdWarnings);
     const warningPids = new Set(warnings.map((w) => w.pid));
     for (const proc of merged) {
       proc.hasWarning = warningPids.has(proc.pid);

--- a/main/preload.js
+++ b/main/preload.js
@@ -11,6 +11,8 @@ contextBridge.exposeInMainWorld('api', {
   getConfig: () => ipcRenderer.invoke('get-config'),
   setConfig: (key, value) => ipcRenderer.invoke('set-config', key, value),
   launchServiceCommand: (command, cwd) => ipcRenderer.invoke('launch-service-command', { command, cwd }),
+  openUrl: (url) => ipcRenderer.invoke('open-url', url),
+  exportSnapshot: () => ipcRenderer.invoke('export-snapshot'),
   onScrollToProcess: (callback) => {
     ipcRenderer.on('scroll-to-process', (_event, pid) => callback(pid));
   },

--- a/main/services/anomaly-detector.js
+++ b/main/services/anomaly-detector.js
@@ -33,4 +33,64 @@ function detect(processes) {
   return warnings;
 }
 
-module.exports = { detect };
+// Track consecutive polls a PID spends over its threshold so we only
+// fire notifications for sustained hot processes (not momentary spikes).
+const thresholdHits = new Map(); // pid -> { cpu: count, mem: count }
+
+function detectThresholds(processes, { cpuThreshold, memThresholdMB, sustainPolls }) {
+  const warnings = [];
+  if (!cpuThreshold && !memThresholdMB) {
+    thresholdHits.clear();
+    return warnings;
+  }
+
+  const activePids = new Set();
+  for (const proc of processes) {
+    activePids.add(proc.pid);
+    let hits = thresholdHits.get(proc.pid);
+    if (!hits) {
+      hits = { cpu: 0, mem: 0 };
+      thresholdHits.set(proc.pid, hits);
+    }
+
+    if (cpuThreshold > 0 && proc.cpu >= cpuThreshold) {
+      hits.cpu += 1;
+      if (hits.cpu === sustainPolls) {
+        warnings.push({
+          pid: proc.pid,
+          port: 0,
+          processName: proc.name,
+          key: `cpu:${proc.pid}`,
+          message: `High CPU: ${proc.name} (PID ${proc.pid}) at ${proc.cpu.toFixed(1)}% for ${sustainPolls} polls`,
+        });
+      }
+    } else {
+      hits.cpu = 0;
+    }
+
+    const memMB = (proc.memKB || 0) / 1024;
+    if (memThresholdMB > 0 && memMB >= memThresholdMB) {
+      hits.mem += 1;
+      if (hits.mem === sustainPolls) {
+        warnings.push({
+          pid: proc.pid,
+          port: 0,
+          processName: proc.name,
+          key: `mem:${proc.pid}`,
+          message: `High memory: ${proc.name} (PID ${proc.pid}) at ${memMB.toFixed(0)} MB for ${sustainPolls} polls`,
+        });
+      }
+    } else {
+      hits.mem = 0;
+    }
+  }
+
+  // Clean up dead pids
+  for (const pid of thresholdHits.keys()) {
+    if (!activePids.has(pid)) thresholdHits.delete(pid);
+  }
+
+  return warnings;
+}
+
+module.exports = { detect, detectThresholds };

--- a/main/services/config.js
+++ b/main/services/config.js
@@ -12,6 +12,10 @@ const DEFAULTS = {
   theme: 'dark',           // 'dark' | 'light'
   customRules: [],         // [{ pattern: string, group: string }]
   profiles: [],            // [{ id, name, services: [{ id, name, pattern, command, cwd }] }]
+  pinnedNames: [],         // [string] — process names pinned to top of their group
+  cpuThreshold: 0,         // percent (0 = disabled)
+  memThresholdMB: 0,       // megabytes (0 = disabled)
+  thresholdSustainPolls: 3, // fire only after N consecutive polls over threshold
 };
 
 const VALID_THEMES = ['dark', 'light'];
@@ -66,6 +70,17 @@ function validate(cfg) {
       return false;
     }
   });
+
+  // pinnedNames: array of strings
+  if (!Array.isArray(result.pinnedNames)) {
+    result.pinnedNames = [];
+  }
+  result.pinnedNames = result.pinnedNames.filter((n) => typeof n === 'string' && n.trim());
+
+  // Thresholds: clamp non-negative numbers
+  result.cpuThreshold = Math.max(0, Math.min(100, Number(result.cpuThreshold) || 0));
+  result.memThresholdMB = Math.max(0, Number(result.memThresholdMB) || 0);
+  result.thresholdSustainPolls = Math.max(1, Math.min(60, Number(result.thresholdSustainPolls) || 3));
 
   // profiles: validate each entry
   if (!Array.isArray(result.profiles)) {

--- a/main/services/notifier.js
+++ b/main/services/notifier.js
@@ -7,6 +7,7 @@ let previousKeys = null; // null = first poll (skip notifications)
 let onClickCallback = null;
 
 function warningKey(w) {
+  if (w.key) return w.key;
   return `${w.port}:${w.processName}`;
 }
 
@@ -46,8 +47,12 @@ function notify(warnings) {
 function showNotification(warning) {
   if (!Notification.isSupported()) return;
 
+  let title = 'Port conflict detected';
+  if (warning.key && warning.key.startsWith('cpu:')) title = 'High CPU usage';
+  else if (warning.key && warning.key.startsWith('mem:')) title = 'High memory usage';
+
   const n = new Notification({
-    title: 'Port conflict detected',
+    title,
     body: warning.message,
     silent: false,
   });

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -13,8 +13,9 @@
     <header class="app-header">
       <h1>Localhost Dashboard</h1>
       <div class="header-controls">
-        <input type="text" id="filter-input" placeholder="Filter processes..." autocomplete="off">
-        <button id="settings-btn" class="settings-btn" title="Settings">&#9881;</button>
+        <input type="text" id="filter-input" placeholder="Filter processes... (press /)" autocomplete="off">
+        <button id="export-btn" class="settings-btn" title="Export snapshot (Ctrl+E)">&#8595;</button>
+        <button id="settings-btn" class="settings-btn" title="Settings (Ctrl+,)">&#9881;</button>
       </div>
     </header>
     <div id="profile-panel-container"></div>

--- a/renderer/js/app.js
+++ b/renderer/js/app.js
@@ -133,6 +133,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     pollInterval = (cfg.pollInterval || 3) * 1000;
     applyTheme(cfg.theme);
     AppState.profiles = cfg.profiles || [];
+    AppState.setPinned(cfg.pinnedNames || []);
   } catch {
     // Config not available yet — use defaults
     AppState.profiles = [];
@@ -150,11 +151,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     settingsBtn.addEventListener('click', openSettings);
   }
 
+  // Export button
+  const exportBtn = document.getElementById('export-btn');
+  if (exportBtn) {
+    exportBtn.addEventListener('click', () => window.api.exportSnapshot());
+  }
+
   // Listen for config changes from the settings panel
   window.addEventListener('config-changed', (e) => {
     const cfg = e.detail;
     applyTheme(cfg.theme);
     AppState.profiles = cfg.profiles || [];
+    AppState.setPinned(cfg.pinnedNames || []);
 
     const newInterval = (cfg.pollInterval || 3) * 1000;
     if (newInterval !== pollInterval) {
@@ -166,7 +174,51 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Listen for notification clicks
   window.api.onScrollToProcess(scrollToProcess);
 
+  // Global keyboard shortcuts
+  document.addEventListener('keydown', handleGlobalKeys);
+
   // Start polling
   startPolling();
   startRefreshTimer();
 });
+
+function handleGlobalKeys(e) {
+  const filterInput = document.getElementById('filter-input');
+  const isTyping = document.activeElement && (
+    document.activeElement.tagName === 'INPUT' ||
+    document.activeElement.tagName === 'TEXTAREA' ||
+    document.activeElement.tagName === 'SELECT'
+  );
+
+  // Escape clears filter and blurs the input
+  if (e.key === 'Escape' && document.activeElement === filterInput) {
+    filterInput.value = '';
+    AppState.setFilter('');
+    filterInput.blur();
+    e.preventDefault();
+    return;
+  }
+
+  // Ctrl/Cmd+E — export snapshot
+  if ((e.ctrlKey || e.metaKey) && e.key === 'e') {
+    e.preventDefault();
+    window.api.exportSnapshot().then((r) => {
+      if (r && r.success) console.log('Snapshot exported:', r.path);
+    });
+    return;
+  }
+
+  // Ctrl/Cmd+, — open settings
+  if ((e.ctrlKey || e.metaKey) && e.key === ',') {
+    e.preventDefault();
+    openSettings();
+    return;
+  }
+
+  // "/" focuses the filter (when not already typing somewhere)
+  if (e.key === '/' && !isTyping) {
+    e.preventDefault();
+    filterInput.focus();
+    filterInput.select();
+  }
+}

--- a/renderer/js/components/context-menu.js
+++ b/renderer/js/components/context-menu.js
@@ -58,12 +58,26 @@ let activeMenu = null;
 function showContextMenu(x, y, proc) {
   hideContextMenu();
 
+  const isPinned = AppState.isPinned(proc.name);
+
   const items = [
     {
       label: 'Kill Process',
       icon: '\u00D7',
       className: 'context-item-danger',
       action: () => showKillConfirm(proc.pid, proc.name),
+    },
+    { separator: true },
+    {
+      label: isPinned ? 'Unpin' : 'Pin to top',
+      icon: '\u2605',
+      action: () => {
+        const updated = AppState.togglePin(proc.name);
+        window.api.setConfig('pinnedNames', updated).then((cfg) => {
+          AppState.setPinned(cfg.pinnedNames || []);
+          AppState.notify();
+        });
+      },
     },
     { separator: true },
     {
@@ -79,6 +93,15 @@ function showContextMenu(x, y, proc) {
       icon: ':',
       action: () => navigator.clipboard.writeText(proc.ports.join(', ')),
     });
+
+    // "Open in browser" for each port
+    for (const port of proc.ports) {
+      items.push({
+        label: `Open :${port} in browser`,
+        icon: '\u2197',
+        action: () => window.api.openUrl(`http://localhost:${port}`),
+      });
+    }
 
     // "Kill all on port X" for each port this process listens on
     for (const port of proc.ports) {

--- a/renderer/js/components/process-table.js
+++ b/renderer/js/components/process-table.js
@@ -111,6 +111,31 @@ function renderSortableHeader(label, column, cssClass) {
   return th;
 }
 
+function renderPortCell(ports) {
+  if (!ports || ports.length === 0) return h('span', {}, '\u2014');
+
+  const container = h('span', { className: 'port-cell' });
+  const shown = ports.slice(0, 2);
+  shown.forEach((port, i) => {
+    const link = h('a', {
+      className: 'port-link',
+      title: `Open http://localhost:${port}`,
+      href: '#',
+    }, String(port));
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      window.api.openUrl(`http://localhost:${port}`);
+    });
+    container.appendChild(link);
+    if (i < shown.length - 1) container.appendChild(h('span', {}, ', '));
+  });
+  if (ports.length > 2) {
+    container.appendChild(h('span', { className: 'port-more' }, ` +${ports.length - 2}`));
+  }
+  return container;
+}
+
 function renderProcessTable(processes) {
   const thead = h('thead', {}, [
     h('tr', {}, [
@@ -151,13 +176,23 @@ function renderProcessTable(processes) {
 
     const isExpanded = AppState.isExpanded(proc.pid);
 
-    const row = h('tr', { dataset: { pid: proc.pid }, className: isExpanded ? 'expanded-row' : '' }, [
-      h('td', { className: 'col-name', title: proc.name }, [
-        h('span', { className: `expand-indicator ${isExpanded ? 'open' : ''}` }, '\u25B6'),
-        h('span', {}, proc.name),
-      ]),
+    const isPinned = AppState.isPinned(proc.name);
+    const rowClasses = [];
+    if (isExpanded) rowClasses.push('expanded-row');
+    if (isPinned) rowClasses.push('pinned-row');
+
+    const nameChildren = [
+      h('span', { className: `expand-indicator ${isExpanded ? 'open' : ''}` }, '\u25B6'),
+    ];
+    if (isPinned) {
+      nameChildren.push(h('span', { className: 'pin-indicator', title: 'Pinned' }, '\u2605'));
+    }
+    nameChildren.push(h('span', {}, proc.name));
+
+    const row = h('tr', { dataset: { pid: proc.pid }, className: rowClasses.join(' ') }, [
+      h('td', { className: 'col-name', title: proc.name }, nameChildren),
       h('td', { className: 'col-pid' }, proc.pid.toString()),
-      h('td', { className: 'col-port' }, formatPort(proc.ports)),
+      h('td', { className: 'col-port' }, [renderPortCell(proc.ports)]),
       cpuCell,
       ramCell,
       h('td', { className: 'col-uptime' }, formatUptime(proc.started)),

--- a/renderer/js/components/settings.js
+++ b/renderer/js/components/settings.js
@@ -99,6 +99,12 @@ function renderSettingsBody() {
     settingsConfig.notifications,
   )));
 
+  // ── Resource Thresholds ────────────────────────────
+  body.appendChild(renderSection('Resource Thresholds', renderThresholds()));
+
+  // ── Pinned Processes ───────────────────────────────
+  body.appendChild(renderSection('Pinned Processes', renderPinnedList()));
+
   // ── Minimize to Tray ───────────────────────────────
   body.appendChild(renderSection('System Tray', renderToggle(
     'minimizeToTray',
@@ -188,6 +194,80 @@ function renderToggle(key, label, value) {
 
   wrapper.appendChild(text);
   wrapper.appendChild(toggle);
+  return wrapper;
+}
+
+// ── Resource Thresholds ────────────────────────────────────
+function renderThresholds() {
+  const wrapper = h('div', { className: 'settings-thresholds' });
+
+  const hint = h('p', { className: 'settings-hint' },
+    'Notify when a process sustains high CPU or memory usage. Set to 0 to disable.');
+  wrapper.appendChild(hint);
+
+  const cpuInput = h('input', {
+    type: 'number', min: '0', max: '100', step: '1',
+    className: 'settings-threshold-input',
+  });
+  cpuInput.value = settingsConfig.cpuThreshold || 0;
+  cpuInput.addEventListener('change', () => {
+    updateSetting('cpuThreshold', Number(cpuInput.value) || 0);
+  });
+
+  const memInput = h('input', {
+    type: 'number', min: '0', step: '50',
+    className: 'settings-threshold-input',
+  });
+  memInput.value = settingsConfig.memThresholdMB || 0;
+  memInput.addEventListener('change', () => {
+    updateSetting('memThresholdMB', Number(memInput.value) || 0);
+  });
+
+  const sustainInput = h('input', {
+    type: 'number', min: '1', max: '60', step: '1',
+    className: 'settings-threshold-input',
+  });
+  sustainInput.value = settingsConfig.thresholdSustainPolls || 3;
+  sustainInput.addEventListener('change', () => {
+    updateSetting('thresholdSustainPolls', Number(sustainInput.value) || 3);
+  });
+
+  wrapper.appendChild(h('div', { className: 'settings-threshold-row' }, [
+    h('label', {}, 'CPU %'), cpuInput,
+    h('label', {}, 'Memory MB'), memInput,
+    h('label', {}, 'Sustain polls'), sustainInput,
+  ]));
+
+  return wrapper;
+}
+
+// ── Pinned Processes ────────────────────────────────────────
+function renderPinnedList() {
+  const wrapper = h('div', { className: 'settings-pinned' });
+  const names = settingsConfig.pinnedNames || [];
+
+  if (names.length === 0) {
+    wrapper.appendChild(h('p', { className: 'settings-profiles-empty' },
+      'No pinned processes. Right-click any process to pin it.'));
+    return wrapper;
+  }
+
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    const row = h('div', { className: 'settings-rule-row' }, [
+      h('span', { className: 'settings-pinned-name' }, name),
+      h('button', {
+        className: 'settings-rule-remove',
+        title: 'Unpin',
+        onClick: () => {
+          const updated = names.filter((_, j) => j !== i);
+          updateSetting('pinnedNames', updated);
+        },
+      }, '\u00D7'),
+    ]);
+    wrapper.appendChild(row);
+  }
+
   return wrapper;
 }
 

--- a/renderer/js/state.js
+++ b/renderer/js/state.js
@@ -13,6 +13,24 @@ const AppState = {
   expandedPids: new Map(), // pid -> { loading: bool, data: null | {...} }
   listeners: [],
   history: new Map(),
+  pinnedNames: new Set(),
+
+  setPinned(names) {
+    this.pinnedNames = new Set(Array.isArray(names) ? names : []);
+  },
+
+  isPinned(name) {
+    return this.pinnedNames.has(name);
+  },
+
+  togglePin(name) {
+    if (this.pinnedNames.has(name)) {
+      this.pinnedNames.delete(name);
+    } else {
+      this.pinnedNames.add(name);
+    }
+    return Array.from(this.pinnedNames);
+  },
 
   update(data) {
     if (!data) return;
@@ -109,6 +127,11 @@ const AppState = {
     const dir = this.sortDirection === 'asc' ? 1 : -1;
 
     return [...processes].sort((a, b) => {
+      // Pinned processes always float to the top regardless of sort column.
+      const ap = this.pinnedNames.has(a.name) ? 1 : 0;
+      const bp = this.pinnedNames.has(b.name) ? 1 : 0;
+      if (ap !== bp) return bp - ap;
+
       let va, vb;
       switch (col) {
         case 'name':

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -163,6 +163,32 @@
   color: var(--accent-cyan);
 }
 
+.port-link {
+  color: var(--accent-cyan);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.port-link:hover {
+  text-decoration: underline;
+  color: var(--accent-blue);
+}
+
+.port-more {
+  color: var(--text-muted);
+}
+
+.pin-indicator {
+  display: inline-block;
+  color: var(--accent-amber);
+  font-size: 10px;
+  margin-right: 4px;
+}
+
+.pinned-row {
+  background: rgba(224, 175, 104, 0.04);
+}
+
 .process-table .col-cpu {
   width: 120px;
   text-align: right;
@@ -856,6 +882,45 @@
 .settings-rule-add {
   padding: 4px 10px;
   font-size: 11px;
+}
+
+.settings-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.settings-threshold-row {
+  display: grid;
+  grid-template-columns: auto 70px auto 90px auto 60px;
+  gap: 8px;
+  align-items: center;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.settings-threshold-input {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  outline: none;
+  transition: border-color var(--transition-speed);
+  width: 100%;
+}
+
+.settings-threshold-input:focus {
+  border-color: var(--accent-blue);
+}
+
+.settings-pinned-name {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent-amber);
 }
 
 @keyframes shake {


### PR DESCRIPTION
- Click a port to open http://localhost:<port>; right-click menu adds
  "Open in browser" per port (restricted to localhost via IPC guard).
- Pin processes by name via the context menu so they float to the top
  of their group; pinned list is editable in Settings.
- Sustain-based CPU% and memory (MB) thresholds fire desktop
  notifications with dedicated titles, reusing the anomaly notifier.
- Export a JSON snapshot of processes, ports, containers, and warnings
  from the header button or Ctrl+E.
- Keyboard shortcuts: / focuses filter, Esc clears it, Ctrl+E exports,
  Ctrl+, opens settings.