### PR TITLE
Process clustering, diff-render, custom window chrome, and UX polish

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -118,6 +118,27 @@ function registerIpcHandlers() {
 
     return updated;
   });
+
+  // ── Custom window controls (frameless) ───────────────────────
+  const winFrom = (e) => BrowserWindow.fromWebContents(e.sender);
+
+  ipcMain.handle('window-minimize', (e) => {
+    winFrom(e)?.minimize();
+  });
+
+  ipcMain.handle('window-maximize-toggle', (e) => {
+    const win = winFrom(e);
+    if (!win) return false;
+    if (win.isMaximized()) win.unmaximize();
+    else win.maximize();
+    return win.isMaximized();
+  });
+
+  ipcMain.handle('window-is-maximized', (e) => !!winFrom(e)?.isMaximized());
+
+  ipcMain.handle('window-close', (e) => {
+    winFrom(e)?.close();
+  });
 }
 
 module.exports = { registerIpcHandlers };

--- a/main/main.js
+++ b/main/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, Menu } = require('electron');
 const path = require('path');
 const { registerIpcHandlers } = require('./ipc-handlers');
 const { createTray, setQuitting, destroy: destroyTray } = require('./tray-manager');
@@ -7,16 +7,39 @@ const config = require('./services/config');
 
 let mainWindow;
 
-function createWindow() {
-  const theme = config.get('theme');
-  const bgColor = theme === 'light' ? '#f0f0f3' : '#1a1b26';
+// Minimal menu: keep clipboard/editing + reload/devtools accelerators working,
+// but the bar is auto-hidden (Alt reveals it) so it doesn't clutter the window.
+function buildAppMenu() {
+  return Menu.buildFromTemplate([
+    { label: 'Edit', role: 'editMenu' },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+      ],
+    },
+  ]);
+}
 
+function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1100,
     height: 750,
     minWidth: 800,
     minHeight: 500,
-    backgroundColor: bgColor,
+    // Transparent bg + Mica so the Windows 11 backdrop shows through the
+    // padding around our opaque cards. (Mica is ignored on Win10.)
+    backgroundColor: '#00000000',
+    backgroundMaterial: 'mica',
+    // Frameless: we draw our own minimal window controls in the header.
+    frame: false,
+    autoHideMenuBar: true,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -26,12 +49,17 @@ function createWindow() {
 
   mainWindow.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'));
 
+  // Tell the renderer when the maximize state changes so it can swap the icon.
+  mainWindow.on('maximize', () => mainWindow.webContents.send('window-state', true));
+  mainWindow.on('unmaximize', () => mainWindow.webContents.send('window-state', false));
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
 }
 
 app.whenReady().then(() => {
+  Menu.setApplicationMenu(buildAppMenu());
   registerIpcHandlers();
   createWindow();
   createTray(mainWindow);

--- a/main/poll-manager.js
+++ b/main/poll-manager.js
@@ -3,7 +3,7 @@ const portCollector = require('./collectors/port-collector');
 const systemCollector = require('./collectors/system-collector');
 const dockerCollector = require('./collectors/docker-collector');
 const { classify, GROUP_META } = require('./services/classifier');
-const { detect, detectThresholds } = require('./services/anomaly-detector');
+const { detect, detectThresholds, detectDuplicates } = require('./services/anomaly-detector');
 const config = require('./services/config');
 
 let busy = false;
@@ -84,7 +84,20 @@ async function collectAll() {
       sustainPolls: config.get('thresholdSustainPolls'),
     });
     warnings.push(...thresholdWarnings);
-    const warningPids = new Set(warnings.map((w) => w.pid));
+    const duplicateWarnings = detectDuplicates(merged, {
+      duplicateThreshold: config.get('duplicateThreshold'),
+    });
+    warnings.push(...duplicateWarnings);
+
+    // A warning can cover one pid (w.pid) or many (w.pids, e.g. duplicates).
+    const warningPids = new Set();
+    for (const w of warnings) {
+      if (Array.isArray(w.pids)) {
+        for (const p of w.pids) warningPids.add(p);
+      } else {
+        warningPids.add(w.pid);
+      }
+    }
     for (const proc of merged) {
       proc.hasWarning = warningPids.has(proc.pid);
     }

--- a/main/preload.js
+++ b/main/preload.js
@@ -16,4 +16,12 @@ contextBridge.exposeInMainWorld('api', {
   onScrollToProcess: (callback) => {
     ipcRenderer.on('scroll-to-process', (_event, pid) => callback(pid));
   },
+  // Custom window controls
+  windowMinimize: () => ipcRenderer.invoke('window-minimize'),
+  windowMaximizeToggle: () => ipcRenderer.invoke('window-maximize-toggle'),
+  windowIsMaximized: () => ipcRenderer.invoke('window-is-maximized'),
+  windowClose: () => ipcRenderer.invoke('window-close'),
+  onWindowState: (callback) => {
+    ipcRenderer.on('window-state', (_event, isMaximized) => callback(isMaximized));
+  },
 });

--- a/main/services/anomaly-detector.js
+++ b/main/services/anomaly-detector.js
@@ -93,4 +93,34 @@ function detectThresholds(processes, { cpuThreshold, memThresholdMB, sustainPoll
   return warnings;
 }
 
-module.exports = { detect, detectThresholds };
+// Detect "process inflation": many instances of the same dev process name,
+// the classic symptom of an AI agent (or watch script) spawning runaways.
+function detectDuplicates(processes, { duplicateThreshold }) {
+  const warnings = [];
+  if (!duplicateThreshold || duplicateThreshold < 2) return warnings;
+
+  const byName = new Map();
+  for (const proc of processes) {
+    if (proc.group !== 'dev') continue;
+    if (!byName.has(proc.name)) byName.set(proc.name, []);
+    byName.get(proc.name).push(proc);
+  }
+
+  for (const [name, procs] of byName) {
+    if (procs.length >= duplicateThreshold) {
+      warnings.push({
+        pid: procs[0].pid,
+        pids: procs.map((p) => p.pid),
+        port: 0,
+        processName: name,
+        key: `dup:${name}`,
+        count: procs.length,
+        message: `${procs.length} ${name} processes running — possible runaway agent. Group the list to bulk-kill them.`,
+      });
+    }
+  }
+
+  return warnings;
+}
+
+module.exports = { detect, detectThresholds, detectDuplicates };

--- a/main/services/config.js
+++ b/main/services/config.js
@@ -16,6 +16,8 @@ const DEFAULTS = {
   cpuThreshold: 0,         // percent (0 = disabled)
   memThresholdMB: 0,       // megabytes (0 = disabled)
   thresholdSustainPolls: 3, // fire only after N consecutive polls over threshold
+  duplicateThreshold: 8,   // warn when N+ dev processes share a name (0/1 = disabled)
+  clusterProcesses: true,  // collapse same-named processes into clusters in the UI
 };
 
 const VALID_THEMES = ['dark', 'light'];
@@ -81,6 +83,8 @@ function validate(cfg) {
   result.cpuThreshold = Math.max(0, Math.min(100, Number(result.cpuThreshold) || 0));
   result.memThresholdMB = Math.max(0, Number(result.memThresholdMB) || 0);
   result.thresholdSustainPolls = Math.max(1, Math.min(60, Number(result.thresholdSustainPolls) || 3));
+  result.duplicateThreshold = Math.max(0, Math.min(100, Number(result.duplicateThreshold) || 0));
+  result.clusterProcesses = !!result.clusterProcesses;
 
   // profiles: validate each entry
   if (!Array.isArray(result.profiles)) {

--- a/main/services/notifier.js
+++ b/main/services/notifier.js
@@ -50,6 +50,7 @@ function showNotification(warning) {
   let title = 'Port conflict detected';
   if (warning.key && warning.key.startsWith('cpu:')) title = 'High CPU usage';
   else if (warning.key && warning.key.startsWith('mem:')) title = 'High memory usage';
+  else if (warning.key && warning.key.startsWith('dup:')) title = 'Too many processes';
 
   const n = new Notification({
     title,

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -14,10 +14,23 @@
       <h1>Localhost Dashboard</h1>
       <div class="header-controls">
         <input type="text" id="filter-input" placeholder="Filter processes... (press /)" autocomplete="off">
+        <button id="cluster-btn" class="settings-btn" title="Group identical processes">&#9783;</button>
         <button id="export-btn" class="settings-btn" title="Export snapshot (Ctrl+E)">&#8595;</button>
         <button id="settings-btn" class="settings-btn" title="Settings (Ctrl+,)">&#9881;</button>
+        <div class="win-controls">
+          <button id="win-min" class="win-btn" title="Minimize" aria-label="Minimize">
+            <svg viewBox="0 0 14 14" aria-hidden="true"><line x1="3" y1="7" x2="11" y2="7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+          </button>
+          <button id="win-max" class="win-btn" title="Maximize" aria-label="Maximize">
+            <svg viewBox="0 0 14 14" aria-hidden="true"><rect x="3.25" y="3.25" width="7.5" height="7.5" rx="1.6" fill="none" stroke="currentColor" stroke-width="1.4"/></svg>
+          </button>
+          <button id="win-close" class="win-btn win-close" title="Close" aria-label="Close">
+            <svg viewBox="0 0 14 14" aria-hidden="true"><line x1="3.6" y1="3.6" x2="10.4" y2="10.4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="10.4" y1="3.6" x2="3.6" y2="10.4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+          </button>
+        </div>
       </div>
     </header>
+    <div id="filter-chips" class="filter-chips"></div>
     <div id="profile-panel-container"></div>
     <main id="process-groups"></main>
     <footer id="status-bar"></footer>
@@ -43,7 +56,9 @@
   </div>
   <script src="js/utils/dom.js"></script>
   <script src="js/utils/format.js"></script>
+  <script src="js/utils/reconcile.js"></script>
   <script src="js/state.js"></script>
+  <script src="js/components/toast.js"></script>
   <script src="js/components/group-header.js"></script>
   <script src="js/components/sparkline.js"></script>
   <script src="js/components/context-menu.js"></script>

--- a/renderer/js/app.js
+++ b/renderer/js/app.js
@@ -13,68 +13,78 @@ async function poll() {
   }
 }
 
+function buildGroupSection(key, group) {
+  const header = h('div', { className: 'group-header' });
+  const tbody = h('tbody', {});
+  const table = h('table', { className: 'process-table' }, [h('thead', {}), tbody]);
+  const body = h('div', { className: 'group-body' }, [table]);
+  const section = h('div', { className: `process-group group-${key}` }, [header, body]);
+  updateGroupSection(section, key, group);
+  return section;
+}
+
+function updateGroupSection(section, key, group) {
+  const collapsed = AppState.isCollapsed(key);
+
+  // Rebuild the header each tick so its stats, count and group-actions menu
+  // reflect current data. It carries no state worth preserving.
+  section.replaceChild(renderGroupHeader(group, collapsed), section.firstChild);
+
+  const body = section.lastChild;
+  body.classList.toggle('collapsed', collapsed);
+
+  const table = body.firstChild;
+  table.replaceChild(buildProcessThead(), table.firstChild);
+
+  const tbody = table.lastChild;
+  reconcileChildren(tbody, collapsed ? [] : buildGroupRowItems(group, key));
+}
+
 function render() {
-  const container = document.getElementById('process-groups');
-  const groups = AppState.getFilteredGroups();
-
-  // Rebuild the group containers
-  container.innerHTML = '';
-
-  // Profile panel (top of the list)
+  // Profile panel (top of the list) — managed independently.
   const profileContainer = document.getElementById('profile-panel-container');
   if (profileContainer) {
     renderProfilePanel(profileContainer);
   }
 
-  let hasAny = false;
+  const container = document.getElementById('process-groups');
+  const groups = AppState.getFilteredGroups();
+  const isFiltering = !!AppState.filter || AppState.quickFilter !== 'all';
 
+  const sectionItems = [];
   for (const key of GROUP_ORDER) {
     const group = groups[key];
     if (!group) continue;
 
-    // Skip empty groups when filtering
-    if (AppState.filter && group.processes.length === 0) continue;
+    // Skip groups that are empty under an active filter.
+    if (isFiltering && group.processes.length === 0) continue;
 
-    hasAny = true;
-    const isCollapsed = AppState.isCollapsed(key);
+    sectionItems.push({
+      key: `g:${key}`,
+      create: () => buildGroupSection(key, group),
+      update: (el) => updateGroupSection(el, key, group),
+    });
 
-    const section = h('div', { className: `process-group group-${key}` });
-    section.appendChild(renderGroupHeader(group, isCollapsed));
-
-    const body = h('div', { className: `group-body ${isCollapsed ? 'collapsed' : ''}` });
-
-    if (group.processes.length > 0) {
-      body.appendChild(renderProcessTable(group.processes));
-    }
-
-    // Set max-height for animation when not collapsed
-    if (!isCollapsed && group.processes.length > 0) {
-      const hasExpanded = group.processes.some((p) => AppState.isExpanded(p.pid));
-      if (hasExpanded) {
-        // Disable max-height constraint when detail rows are present
-        body.style.maxHeight = 'none';
-      } else {
-        body.style.maxHeight = `${group.processes.length * 34 + 30}px`;
-      }
-    }
-
-    section.appendChild(body);
-    container.appendChild(section);
-
-    // Render Docker containers section right after the docker process group
+    // Docker containers section sits right after the docker process group.
     if (key === 'docker' && AppState.containers && AppState.containers.length > 0) {
-      hasAny = true;
-      const containerSection = renderContainerSection(AppState.containers);
-      if (containerSection) {
-        container.appendChild(containerSection);
-      }
+      const containers = AppState.containers;
+      sectionItems.push({
+        key: 'g:_containers',
+        create: () => buildContainerSection(),
+        update: (el) => updateContainerSection(el, containers),
+      });
     }
   }
 
-  if (!hasAny) {
-    container.appendChild(
-      h('div', { className: 'no-processes' }, 'No processes found')
-    );
+  // Drop any leftover empty-state placeholder before reconciling.
+  const placeholder = container.querySelector('.no-processes');
+  if (placeholder) placeholder.remove();
+
+  if (sectionItems.length === 0) {
+    container.innerHTML = '';
+    container.appendChild(h('div', { className: 'no-processes' }, 'No processes found'));
+  } else {
+    reconcileChildren(container, sectionItems);
   }
 
   renderStatusBar();
@@ -92,16 +102,29 @@ function startRefreshTimer() {
 function scrollToProcess(pid) {
   if (pid == null) return; // summary notification, just show the window
 
+  const safePid = Number(pid);
+  if (!Number.isFinite(safePid)) return;
+
   // Expand all groups so the process is visible
   for (const key of GROUP_ORDER) {
     if (AppState.isCollapsed(key)) {
       AppState.collapsedGroups.delete(key);
     }
   }
-  AppState.notify();
 
-  const safePid = Number(pid);
-  if (!Number.isFinite(safePid)) return;
+  // If the process is hidden inside a collapsed cluster, expand that cluster too.
+  for (const [gkey, g] of Object.entries(AppState.groups)) {
+    const found = g.processes.find((p) => p.pid === safePid);
+    if (found) {
+      const sameName = g.processes.filter((p) => p.name === found.name).length;
+      if (AppState.clusterMode && sameName >= CLUSTER_MIN) {
+        AppState.expandedClusters.add(`c:${gkey}:${found.name}`);
+      }
+      break;
+    }
+  }
+
+  AppState.notify();
 
   // Allow a frame for the DOM to update, then scroll & highlight
   requestAnimationFrame(() => {
@@ -115,6 +138,72 @@ function scrollToProcess(pid) {
 
 function applyTheme(theme) {
   document.documentElement.setAttribute('data-theme', theme || 'dark');
+}
+
+const QUICK_FILTERS = [
+  { id: 'all', label: 'All' },
+  { id: 'port', label: 'With port' },
+  { id: 'idle', label: 'Idle' },
+];
+
+function renderChips() {
+  const bar = document.getElementById('filter-chips');
+  if (!bar) return;
+  bar.innerHTML = '';
+  for (const chip of QUICK_FILTERS) {
+    const active = AppState.quickFilter === chip.id;
+    const btn = h('button', { className: `chip ${active ? 'chip-active' : ''}` }, chip.label);
+    btn.addEventListener('click', () => {
+      AppState.setQuickFilter(chip.id);
+      renderChips();
+    });
+    bar.appendChild(btn);
+  }
+}
+
+const ICON_MAXIMIZE =
+  '<svg viewBox="0 0 14 14" aria-hidden="true"><rect x="3.25" y="3.25" width="7.5" height="7.5" rx="1.6" fill="none" stroke="currentColor" stroke-width="1.4"/></svg>';
+const ICON_RESTORE =
+  '<svg viewBox="0 0 14 14" aria-hidden="true"><rect x="3" y="4.7" width="6.3" height="6.3" rx="1.4" fill="none" stroke="currentColor" stroke-width="1.3"/><path d="M5.2 4.7 V3.4 A1.1 1.1 0 0 1 6.3 2.3 H10.6 A1.1 1.1 0 0 1 11.7 3.4 V7.7 A1.1 1.1 0 0 1 10.6 8.8 H9.3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>';
+
+function setupWindowControls() {
+  const minBtn = document.getElementById('win-min');
+  const maxBtn = document.getElementById('win-max');
+  const closeBtn = document.getElementById('win-close');
+  if (!minBtn || !maxBtn || !closeBtn || !window.api.windowMinimize) return;
+
+  const setMaxIcon = (isMax) => {
+    maxBtn.innerHTML = isMax ? ICON_RESTORE : ICON_MAXIMIZE;
+    maxBtn.title = isMax ? 'Restore' : 'Maximize';
+  };
+
+  minBtn.addEventListener('click', () => window.api.windowMinimize());
+  closeBtn.addEventListener('click', () => window.api.windowClose());
+  maxBtn.addEventListener('click', async () => {
+    const isMax = await window.api.windowMaximizeToggle();
+    setMaxIcon(isMax);
+  });
+
+  window.api.onWindowState(setMaxIcon);
+  window.api.windowIsMaximized().then(setMaxIcon).catch(() => {});
+
+  // Double-clicking the empty title-bar area toggles maximize (standard behavior).
+  const header = document.querySelector('.app-header');
+  if (header) {
+    header.addEventListener('dblclick', (e) => {
+      if (e.target.closest('.header-controls')) return;
+      window.api.windowMaximizeToggle();
+    });
+  }
+}
+
+function updateClusterBtn() {
+  const btn = document.getElementById('cluster-btn');
+  if (!btn) return;
+  btn.classList.toggle('active', AppState.clusterMode);
+  btn.title = AppState.clusterMode
+    ? 'Identical processes grouped — click to show all'
+    : 'Click to group identical processes';
 }
 
 function startPolling() {
@@ -134,9 +223,24 @@ document.addEventListener('DOMContentLoaded', async () => {
     applyTheme(cfg.theme);
     AppState.profiles = cfg.profiles || [];
     AppState.setPinned(cfg.pinnedNames || []);
+    AppState.clusterMode = cfg.clusterProcesses !== false;
   } catch {
     // Config not available yet — use defaults
     AppState.profiles = [];
+  }
+
+  setupWindowControls();
+  renderChips();
+  updateClusterBtn();
+
+  // Cluster toggle button
+  const clusterBtn = document.getElementById('cluster-btn');
+  if (clusterBtn) {
+    clusterBtn.addEventListener('click', () => {
+      const val = AppState.toggleClusterMode();
+      updateClusterBtn();
+      window.api.setConfig('clusterProcesses', val);
+    });
   }
 
   // Filter input
@@ -163,12 +267,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     applyTheme(cfg.theme);
     AppState.profiles = cfg.profiles || [];
     AppState.setPinned(cfg.pinnedNames || []);
+    AppState.clusterMode = cfg.clusterProcesses !== false;
+    updateClusterBtn();
 
     const newInterval = (cfg.pollInterval || 3) * 1000;
     if (newInterval !== pollInterval) {
       pollInterval = newInterval;
       startPolling();
     }
+
+    AppState.notify();
   });
 
   // Listen for notification clicks

--- a/renderer/js/components/container-table.js
+++ b/renderer/js/components/container-table.js
@@ -20,47 +20,8 @@ function formatContainerPorts(ports) {
   }).join(', ');
 }
 
-function renderContainerSection(containers) {
-  if (!containers || containers.length === 0) return null;
-
-  const section = h('div', { className: 'process-group group-containers' });
-
-  // Header
-  const isCollapsed = AppState.isCollapsed('_containers');
-  const runningCount = containers.filter((c) => c.state === 'running').length;
-
-  const toggle = h('span', {
-    className: `group-toggle ${isCollapsed ? 'collapsed' : ''}`,
-  }, '\u25BC');
-  const icon = h('span', { className: 'group-icon' }, '\uD83D\uDC33');
-  const name = h('span', { className: 'group-name' }, 'Containers');
-  const count = h('span', { className: 'group-count' }, `${containers.length}`);
-  const stats = h('span', { className: 'group-stats' }, [
-    h('span', {}, `${runningCount} running`),
-  ]);
-
-  const header = h('div', { className: 'group-header' }, [
-    toggle, icon, name, count, stats,
-  ]);
-
-  header.addEventListener('click', () => AppState.toggleGroup('_containers'));
-
-  section.appendChild(header);
-
-  // Body
-  const body = h('div', { className: `group-body ${isCollapsed ? 'collapsed' : ''}` });
-
-  if (!isCollapsed) {
-    body.appendChild(renderContainerTable(containers));
-    body.style.maxHeight = `${containers.length * 34 + 30}px`;
-  }
-
-  section.appendChild(body);
-  return section;
-}
-
-function renderContainerTable(containers) {
-  const thead = h('thead', {}, [
+function containerThead() {
+  return h('thead', {}, [
     h('tr', {}, [
       h('th', { className: 'col-container-name' }, 'Name'),
       h('th', { className: 'col-container-image' }, 'Image'),
@@ -69,25 +30,63 @@ function renderContainerTable(containers) {
       h('th', { className: 'col-container-id' }, 'ID'),
     ]),
   ]);
+}
 
-  const rows = [];
-  for (const container of containers) {
-    const stateClass = containerStateClass(container.state);
+function populateContainerRow(tr, container) {
+  tr.innerHTML = '';
+  const stateClass = containerStateClass(container.state);
+  tr.appendChild(h('td', { className: 'col-container-name', title: container.name }, container.name));
+  tr.appendChild(h('td', { className: 'col-container-image', title: container.image }, container.image));
+  tr.appendChild(h('td', { className: `col-container-status ${stateClass}` }, [
+    h('span', { className: `container-state-dot ${stateClass}` }, ''),
+    h('span', {}, container.status),
+  ]));
+  tr.appendChild(h('td', { className: 'col-container-ports' }, formatContainerPorts(container.ports)));
+  tr.appendChild(h('td', { className: 'col-container-id' }, container.id.substring(0, 12)));
+}
 
-    const row = h('tr', {}, [
-      h('td', { className: 'col-container-name', title: container.name }, container.name),
-      h('td', { className: 'col-container-image', title: container.image }, container.image),
-      h('td', { className: `col-container-status ${stateClass}` }, [
-        h('span', { className: `container-state-dot ${stateClass}` }, ''),
-        h('span', {}, container.status),
-      ]),
-      h('td', { className: 'col-container-ports' }, formatContainerPorts(container.ports)),
-      h('td', { className: 'col-container-id' }, container.id.substring(0, 12)),
-    ]);
+function buildContainerRow(container) {
+  const tr = h('tr', {});
+  populateContainerRow(tr, container);
+  return tr;
+}
 
-    rows.push(row);
-  }
+// Build a persistent container section (header + table) for the reconciler.
+function buildContainerSection() {
+  const header = h('div', { className: 'group-header' }, [
+    h('span', { className: 'group-toggle' }, '\u25BC'),
+    h('span', { className: 'group-icon' }, '\uD83D\uDC33'),
+    h('span', { className: 'group-name' }, 'Containers'),
+    h('span', { className: 'group-count' }, ''),
+    h('span', { className: 'group-stats' }, [h('span', {}, '')]),
+  ]);
+  header.addEventListener('click', () => AppState.toggleGroup('_containers'));
 
-  const tbody = h('tbody', {}, rows);
-  return h('table', { className: 'process-table container-table' }, [thead, tbody]);
+  const tbody = h('tbody', {});
+  const table = h('table', { className: 'process-table container-table' }, [containerThead(), tbody]);
+  const body = h('div', { className: 'group-body' }, [table]);
+
+  const section = h('div', { className: 'process-group group-containers' }, [header, body]);
+  return section;
+}
+
+function updateContainerSection(section, containers) {
+  const isCollapsed = AppState.isCollapsed('_containers');
+  const runningCount = containers.filter((c) => c.state === 'running').length;
+
+  const header = section.querySelector('.group-header');
+  header.querySelector('.group-toggle').className = `group-toggle ${isCollapsed ? 'collapsed' : ''}`;
+  header.querySelector('.group-count').textContent = `${containers.length}`;
+  header.querySelector('.group-stats').firstChild.textContent = `${runningCount} running`;
+
+  const body = section.querySelector('.group-body');
+  body.classList.toggle('collapsed', isCollapsed);
+
+  const tbody = section.querySelector('tbody');
+  const items = isCollapsed ? [] : containers.map((c) => ({
+    key: `ct:${c.id}`,
+    create: () => buildContainerRow(c),
+    update: (el) => populateContainerRow(el, c),
+  }));
+  reconcileChildren(tbody, items);
 }

--- a/renderer/js/components/kill-button.js
+++ b/renderer/js/components/kill-button.js
@@ -10,29 +10,13 @@ function renderKillButton(pid, processName) {
 }
 
 function showKillConfirm(pid, processName) {
-  const modal = document.getElementById('confirm-modal');
-  const message = document.getElementById('confirm-message');
-  const yesBtn = document.getElementById('confirm-yes');
-  const noBtn = document.getElementById('confirm-no');
-
-  message.textContent = `Kill ${processName} (PID ${pid})?`;
-  modal.classList.remove('hidden');
-
-  const cleanup = () => {
-    modal.classList.add('hidden');
-    yesBtn.replaceWith(yesBtn.cloneNode(true));
-    noBtn.replaceWith(noBtn.cloneNode(true));
-  };
-
-  yesBtn.addEventListener('click', async () => {
-    cleanup();
-    const result = await window.api.killProcess(pid);
-    if (!result.success) {
-      showError(result.error);
-    }
-  }, { once: true });
-
-  noBtn.addEventListener('click', cleanup, { once: true });
+  // Delayed kill with an Undo window instead of a blocking confirm dialog —
+  // a misclick is recoverable, and the flow doesn't interrupt your work.
+  showUndoToast(
+    `Killing ${processName} (PID ${pid})`,
+    () => window.api.killProcess(pid),
+    { delay: 5000 }
+  );
 }
 
 function showBatchKillConfirm(title, processes, onConfirm) {

--- a/renderer/js/components/process-table.js
+++ b/renderer/js/components/process-table.js
@@ -1,25 +1,7 @@
-function renderDetailRow(pid) {
-  const entry = AppState.getExpandedData(pid);
-  const detailTd = h('td', { className: 'detail-cell' });
-  detailTd.setAttribute('colspan', '7');
+// Minimum identical-named processes before they collapse into a cluster row.
+const CLUSTER_MIN = 3;
 
-  if (!entry || entry.loading) {
-    detailTd.appendChild(h('div', { className: 'detail-panel' }, [
-      h('span', { className: 'detail-loading' }, 'Loading details...'),
-    ]));
-  } else if (!entry.data) {
-    detailTd.appendChild(h('div', { className: 'detail-panel' }, [
-      h('span', { className: 'detail-error' }, 'Could not retrieve process details.'),
-    ]));
-  } else {
-    detailTd.appendChild(renderDetailContent(entry.data));
-  }
-
-  const detailRow = h('tr', { className: 'detail-row' }, [detailTd]);
-  detailRow.addEventListener('click', (e) => e.stopPropagation());
-  return detailRow;
-}
-
+// ── Detail row (expanded process) ──────────────────────────────
 function renderDetailContent(data) {
   const sections = [];
 
@@ -95,10 +77,38 @@ function renderDetailSection(title, content) {
   ]);
 }
 
+function populateDetailRow(tr, pid) {
+  tr.innerHTML = '';
+  const entry = AppState.getExpandedData(pid);
+  const detailTd = h('td', { className: 'detail-cell' });
+  detailTd.setAttribute('colspan', '7');
+
+  if (!entry || entry.loading) {
+    detailTd.appendChild(h('div', { className: 'detail-panel' }, [
+      h('span', { className: 'detail-loading' }, 'Loading details...'),
+    ]));
+  } else if (!entry.data) {
+    detailTd.appendChild(h('div', { className: 'detail-panel' }, [
+      h('span', { className: 'detail-error' }, 'Could not retrieve process details.'),
+    ]));
+  } else {
+    detailTd.appendChild(renderDetailContent(entry.data));
+  }
+  tr.appendChild(detailTd);
+}
+
+function buildDetailRow(pid) {
+  const tr = h('tr', { className: 'detail-row' });
+  tr.addEventListener('click', (e) => e.stopPropagation());
+  populateDetailRow(tr, pid);
+  return tr;
+}
+
+// ── Table header ───────────────────────────────────────────────
 function renderSortableHeader(label, column, cssClass) {
   const isActive = AppState.sortColumn === column;
   const arrow = isActive
-    ? (AppState.sortDirection === 'asc' ? ' \u25B2' : ' \u25BC')
+    ? (AppState.sortDirection === 'asc' ? ' ▲' : ' ▼')
     : '';
   const activeClass = isActive ? ' sort-active' : '';
 
@@ -111,8 +121,23 @@ function renderSortableHeader(label, column, cssClass) {
   return th;
 }
 
+function buildProcessThead() {
+  return h('thead', {}, [
+    h('tr', {}, [
+      renderSortableHeader('Name', 'name', 'col-name'),
+      renderSortableHeader('PID', 'pid', 'col-pid'),
+      renderSortableHeader('Port', 'port', 'col-port'),
+      renderSortableHeader('CPU', 'cpu', 'col-cpu'),
+      renderSortableHeader('RAM', 'ram', 'col-ram'),
+      renderSortableHeader('Uptime', 'uptime', 'col-uptime'),
+      h('th', { className: 'col-action' }, ''),
+    ]),
+  ]);
+}
+
+// ── Port cell ──────────────────────────────────────────────────
 function renderPortCell(ports) {
-  if (!ports || ports.length === 0) return h('span', {}, '\u2014');
+  if (!ports || ports.length === 0) return h('span', {}, '—');
 
   const container = h('span', { className: 'port-cell' });
   const shown = ports.slice(0, 2);
@@ -136,89 +161,206 @@ function renderPortCell(ports) {
   return container;
 }
 
-function renderProcessTable(processes) {
-  const thead = h('thead', {}, [
-    h('tr', {}, [
-      renderSortableHeader('Name', 'name', 'col-name'),
-      renderSortableHeader('PID', 'pid', 'col-pid'),
-      renderSortableHeader('Port', 'port', 'col-port'),
-      renderSortableHeader('CPU', 'cpu', 'col-cpu'),
-      renderSortableHeader('RAM', 'ram', 'col-ram'),
-      renderSortableHeader('Uptime', 'uptime', 'col-uptime'),
-      h('th', { className: 'col-action' }, ''),
-    ]),
+// ── Process row (reusable: build once, update in place) ────────
+function populateRow(tr, proc, opts = {}) {
+  tr._proc = proc;
+  tr.innerHTML = '';
+  tr.dataset.pid = proc.pid;
+
+  const history = AppState.getHistory(proc.pid);
+  const cpuHistory = history.map((e) => e.cpu);
+  const ramHistory = history.map((e) => e.memKB);
+
+  const cpuColor = proc.cpu >= 50 ? 'var(--accent-red)' : proc.cpu >= 15 ? 'var(--accent-amber)' : 'var(--accent-green)';
+  const cpuFill = proc.cpu >= 50 ? 'rgba(247, 118, 142, 0.15)' : proc.cpu >= 15 ? 'rgba(224, 175, 104, 0.15)' : 'rgba(158, 206, 106, 0.15)';
+
+  const cpuSparkline = renderSparkline(cpuHistory, { stroke: cpuColor, fill: cpuFill });
+  cpuSparkline.addEventListener('click', (e) => { e.stopPropagation(); showSparklineDetail(proc.pid, 'cpu'); });
+
+  const ramSparkline = renderSparkline(ramHistory, { stroke: 'var(--accent-purple)', fill: 'rgba(187, 154, 247, 0.15)' });
+  ramSparkline.addEventListener('click', (e) => { e.stopPropagation(); showSparklineDetail(proc.pid, 'ram'); });
+
+  const isExpanded = AppState.isExpanded(proc.pid);
+  const isPinned = AppState.isPinned(proc.name);
+
+  tr.className = 'proc-row';
+  if (opts.isClusterChild) tr.classList.add('cluster-child');
+  if (isExpanded) tr.classList.add('expanded-row');
+  if (isPinned) tr.classList.add('pinned-row');
+  if (proc.hasWarning) tr.classList.add('warning-row');
+
+  const nameChildren = [
+    h('span', { className: `expand-indicator ${isExpanded ? 'open' : ''}` }, '▶'),
+  ];
+  if (isPinned) {
+    nameChildren.push(h('span', { className: 'pin-indicator', title: 'Pinned' }, '★'));
+  }
+  nameChildren.push(h('span', {}, proc.name));
+
+  const cpuCell = h('td', { className: `col-cpu ${cpuClass(proc.cpu)}` }, [
+    h('span', { className: 'cell-value' }, formatCpu(proc.cpu)),
+    cpuSparkline,
   ]);
 
-  const rows = [];
-  for (const proc of processes) {
-    const history = AppState.getHistory(proc.pid);
-    const cpuHistory = history.map((entry) => entry.cpu);
-    const ramHistory = history.map((entry) => entry.memKB);
+  const ramCell = h('td', { className: 'col-ram' }, [
+    h('span', { className: 'cell-value' }, formatBytes(proc.memKB)),
+    ramSparkline,
+  ]);
 
-    const cpuColor = proc.cpu >= 50 ? 'var(--accent-red)' : proc.cpu >= 15 ? 'var(--accent-amber)' : 'var(--accent-green)';
-    const cpuFill = proc.cpu >= 50 ? 'rgba(247, 118, 142, 0.15)' : proc.cpu >= 15 ? 'rgba(224, 175, 104, 0.15)' : 'rgba(158, 206, 106, 0.15)';
+  tr.appendChild(h('td', { className: 'col-name', title: proc.name }, nameChildren));
+  tr.appendChild(h('td', { className: 'col-pid' }, proc.pid.toString()));
+  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(proc.ports)]));
+  tr.appendChild(cpuCell);
+  tr.appendChild(ramCell);
+  tr.appendChild(h('td', { className: 'col-uptime' }, formatUptime(proc.started)));
+  tr.appendChild(h('td', { className: 'col-action' }, [renderKillButton(proc.pid, proc.name)]));
+}
 
-    const cpuSparkline = renderSparkline(cpuHistory, { stroke: cpuColor, fill: cpuFill });
-    cpuSparkline.addEventListener('click', (e) => { e.stopPropagation(); showSparklineDetail(proc.pid, 'cpu'); });
+function buildRow(proc, opts = {}) {
+  const tr = h('tr', { dataset: { pid: proc.pid } });
+  tr.style.cursor = 'pointer';
+  tr.addEventListener('click', () => {
+    if (tr._proc) AppState.toggleExpanded(tr._proc.pid);
+  });
+  tr.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (tr._proc) showContextMenu(e.clientX, e.clientY, tr._proc);
+  });
+  populateRow(tr, proc, opts);
+  return tr;
+}
 
-    const ramSparkline = renderSparkline(ramHistory, { stroke: 'var(--accent-purple)', fill: 'rgba(187, 154, 247, 0.15)' });
-    ramSparkline.addEventListener('click', (e) => { e.stopPropagation(); showSparklineDetail(proc.pid, 'ram'); });
+// ── Cluster row (aggregate of same-named processes) ────────────
+function clusterAggregate(procs) {
+  let totalCpu = 0;
+  let totalMem = 0;
+  let oldest = Infinity;
+  const portSet = new Set();
+  let anyWarning = false;
 
-    const cpuCell = h('td', { className: `col-cpu ${cpuClass(proc.cpu)}` }, [
-      h('span', { className: 'cell-value' }, formatCpu(proc.cpu)),
-      cpuSparkline,
-    ]);
+  for (const p of procs) {
+    totalCpu += p.cpu;
+    totalMem += p.memKB || 0;
+    if (p.started && p.started < oldest) oldest = p.started;
+    if (p.ports) for (const port of p.ports) portSet.add(port);
+    if (p.hasWarning) anyWarning = true;
+  }
 
-    const ramCell = h('td', { className: 'col-ram' }, [
-      h('span', { className: 'cell-value' }, formatBytes(proc.memKB)),
-      ramSparkline,
-    ]);
+  return {
+    totalCpu,
+    totalMem,
+    oldest: oldest === Infinity ? null : oldest,
+    ports: Array.from(portSet).sort((a, b) => a - b),
+    anyWarning,
+  };
+}
 
-    const isExpanded = AppState.isExpanded(proc.pid);
+function populateClusterRow(tr, cluster) {
+  tr._cluster = cluster;
+  tr.innerHTML = '';
 
-    const isPinned = AppState.isPinned(proc.name);
-    const rowClasses = [];
-    if (isExpanded) rowClasses.push('expanded-row');
-    if (isPinned) rowClasses.push('pinned-row');
+  const { procs, name, key } = cluster;
+  const agg = clusterAggregate(procs);
+  const expanded = AppState.isClusterExpanded(key);
 
-    const nameChildren = [
-      h('span', { className: `expand-indicator ${isExpanded ? 'open' : ''}` }, '\u25B6'),
-    ];
-    if (isPinned) {
-      nameChildren.push(h('span', { className: 'pin-indicator', title: 'Pinned' }, '\u2605'));
-    }
-    nameChildren.push(h('span', {}, proc.name));
+  tr.className = 'cluster-row';
+  if (expanded) tr.classList.add('cluster-open');
+  if (agg.anyWarning) tr.classList.add('warning-row');
 
-    const row = h('tr', { dataset: { pid: proc.pid }, className: rowClasses.join(' ') }, [
-      h('td', { className: 'col-name', title: proc.name }, nameChildren),
-      h('td', { className: 'col-pid' }, proc.pid.toString()),
-      h('td', { className: 'col-port' }, [renderPortCell(proc.ports)]),
-      cpuCell,
-      ramCell,
-      h('td', { className: 'col-uptime' }, formatUptime(proc.started)),
-      h('td', { className: 'col-action' }, [renderKillButton(proc.pid, proc.name)]),
-    ]);
+  const nameCell = h('td', { className: 'col-name' }, [
+    h('span', { className: `expand-indicator ${expanded ? 'open' : ''}` }, '▶'),
+    h('span', { className: 'cluster-name' }, name),
+    h('span', { className: 'cluster-badge' }, `×${procs.length}`),
+  ]);
 
-    row.addEventListener('click', () => AppState.toggleExpanded(proc.pid));
-    row.addEventListener('contextmenu', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      showContextMenu(e.clientX, e.clientY, proc);
+  const cpuCell = h('td', { className: `col-cpu ${cpuClass(agg.totalCpu)}` }, [
+    h('span', { className: 'cell-value' }, formatCpu(agg.totalCpu)),
+  ]);
+  const ramCell = h('td', { className: 'col-ram' }, [
+    h('span', { className: 'cell-value' }, formatBytes(agg.totalMem)),
+  ]);
+
+  const killBtn = h('button', {
+    className: 'kill-btn kill-btn-cluster',
+    title: `Kill all ${procs.length} ${name} processes`,
+  }, `Kill ${procs.length}`);
+  killBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    showBatchKillConfirm(
+      `Kill all ${tr._cluster.procs.length} ${name} process(es)?`,
+      tr._cluster.procs,
+      (pids) => window.api.killProcesses(pids)
+    );
+  });
+
+  tr.appendChild(nameCell);
+  tr.appendChild(h('td', { className: 'col-pid cluster-pid' }, `${procs.length} pids`));
+  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(agg.ports)]));
+  tr.appendChild(cpuCell);
+  tr.appendChild(ramCell);
+  tr.appendChild(h('td', { className: 'col-uptime' }, formatUptime(agg.oldest)));
+  tr.appendChild(h('td', { className: 'col-action' }, [killBtn]));
+}
+
+function buildClusterRow(cluster) {
+  const tr = h('tr', {});
+  tr.style.cursor = 'pointer';
+  tr.addEventListener('click', () => {
+    if (tr._cluster) AppState.toggleCluster(tr._cluster.key);
+  });
+  populateClusterRow(tr, cluster);
+  return tr;
+}
+
+// ── Build the reconciler item list for one group's tbody ───────
+function buildGroupRowItems(group, groupKey) {
+  const items = [];
+  const procs = group.processes;
+
+  const pushProcess = (proc, opts) => {
+    items.push({
+      key: `p:${proc.pid}`,
+      create: () => buildRow(proc, opts),
+      update: (el) => populateRow(el, proc, opts),
     });
-    row.style.cursor = 'pointer';
-
-    if (proc.hasWarning) {
-      row.classList.add('warning-row');
+    if (AppState.isExpanded(proc.pid)) {
+      items.push({
+        key: `d:${proc.pid}`,
+        create: () => buildDetailRow(proc.pid),
+        update: (el) => populateDetailRow(el, proc.pid),
+      });
     }
+  };
 
-    rows.push(row);
+  if (!AppState.clusterMode) {
+    for (const proc of procs) pushProcess(proc);
+    return items;
+  }
 
-    // Render detail row if expanded
-    if (isExpanded) {
-      rows.push(renderDetailRow(proc.pid));
+  // Group by name; each cluster anchors at its first (highest-sorted) member.
+  const byName = new Map();
+  for (const proc of procs) {
+    if (!byName.has(proc.name)) byName.set(proc.name, []);
+    byName.get(proc.name).push(proc);
+  }
+
+  for (const [name, members] of byName) {
+    if (members.length >= CLUSTER_MIN) {
+      const key = `c:${groupKey}:${name}`;
+      const cluster = { key, groupKey, name, procs: members };
+      items.push({
+        key,
+        create: () => buildClusterRow(cluster),
+        update: (el) => populateClusterRow(el, cluster),
+      });
+      if (AppState.isClusterExpanded(key)) {
+        for (const proc of members) pushProcess(proc, { isClusterChild: true });
+      }
+    } else {
+      for (const proc of members) pushProcess(proc);
     }
   }
 
-  const tbody = h('tbody', {}, rows);
-  return h('table', { className: 'process-table' }, [thead, tbody]);
+  return items;
 }

--- a/renderer/js/components/settings.js
+++ b/renderer/js/components/settings.js
@@ -102,6 +102,9 @@ function renderSettingsBody() {
   // ── Resource Thresholds ────────────────────────────
   body.appendChild(renderSection('Resource Thresholds', renderThresholds()));
 
+  // ── Process Grouping ───────────────────────────────
+  body.appendChild(renderSection('Process Grouping', renderGrouping()));
+
   // ── Pinned Processes ───────────────────────────────
   body.appendChild(renderSection('Pinned Processes', renderPinnedList()));
 
@@ -236,6 +239,38 @@ function renderThresholds() {
     h('label', {}, 'CPU %'), cpuInput,
     h('label', {}, 'Memory MB'), memInput,
     h('label', {}, 'Sustain polls'), sustainInput,
+  ]));
+
+  return wrapper;
+}
+
+// ── Process Grouping ───────────────────────────────────────
+function renderGrouping() {
+  const wrapper = h('div', { className: 'settings-grouping' });
+
+  wrapper.appendChild(h('p', { className: 'settings-hint' },
+    'Collapse identical process names (e.g. many node.exe from an agent) into a single row with a bulk-kill button.'));
+
+  wrapper.appendChild(renderToggle(
+    'clusterProcesses',
+    'Group identical processes',
+    settingsConfig.clusterProcesses !== false,
+  ));
+
+  wrapper.appendChild(h('p', { className: 'settings-hint', style: 'margin-top:12px' },
+    'Warn when this many dev processes share a name. Set to 0 to disable.'));
+
+  const dupInput = h('input', {
+    type: 'number', min: '0', max: '100', step: '1',
+    className: 'settings-threshold-input',
+  });
+  dupInput.value = settingsConfig.duplicateThreshold || 0;
+  dupInput.addEventListener('change', () => {
+    updateSetting('duplicateThreshold', Number(dupInput.value) || 0);
+  });
+
+  wrapper.appendChild(h('div', { className: 'settings-dup-row' }, [
+    h('label', {}, 'Warn at'), dupInput, h('label', {}, 'duplicates'),
   ]));
 
   return wrapper;

--- a/renderer/js/components/toast.js
+++ b/renderer/js/components/toast.js
@@ -1,0 +1,92 @@
+/**
+ * Lightweight toast notifications, including a "delayed action with Undo"
+ * pattern used for kills: the action is scheduled, a countdown toast appears,
+ * and the action only commits if the user doesn't click Undo in time.
+ */
+
+function getToastContainer() {
+  let container = document.getElementById('toast-container');
+  if (!container) {
+    container = h('div', { id: 'toast-container' });
+    document.body.appendChild(container);
+  }
+  return container;
+}
+
+function dismissToast(toast) {
+  if (!toast || toast.__dismissed) return;
+  toast.__dismissed = true;
+  toast.classList.add('toast-leaving');
+  setTimeout(() => toast.remove(), 200);
+}
+
+/**
+ * Simple informational toast that auto-dismisses.
+ * @param {string} message
+ * @param {{ type?: 'info'|'success'|'error', duration?: number }} [opts]
+ */
+function showToast(message, opts = {}) {
+  const type = opts.type || 'info';
+  const duration = opts.duration || 3000;
+
+  const toast = h('div', { className: `toast toast-${type}` }, [
+    h('span', { className: 'toast-message' }, message),
+  ]);
+
+  getToastContainer().appendChild(toast);
+  setTimeout(() => dismissToast(toast), duration);
+  return toast;
+}
+
+/**
+ * Schedule an action that the user can cancel via an Undo button before a
+ * countdown elapses. Returns nothing — fully self-managing.
+ *
+ * @param {string} message      e.g. "Killing node.exe (PID 1234)"
+ * @param {() => (Promise<any>|any)} commit  Runs if not undone.
+ * @param {{ delay?: number, onError?: (err: any) => void }} [opts]
+ */
+function showUndoToast(message, commit, opts = {}) {
+  const delay = opts.delay || 5000;
+  let remaining = Math.ceil(delay / 1000);
+  let cancelled = false;
+
+  const countdownEl = h('span', { className: 'toast-countdown' }, `${remaining}s`);
+  const undoBtn = h('button', { className: 'toast-undo' }, 'Undo');
+
+  const toast = h('div', { className: 'toast toast-pending' }, [
+    h('span', { className: 'toast-message' }, message),
+    countdownEl,
+    undoBtn,
+  ]);
+
+  getToastContainer().appendChild(toast);
+
+  const tick = setInterval(() => {
+    remaining -= 1;
+    countdownEl.textContent = `${Math.max(0, remaining)}s`;
+  }, 1000);
+
+  const timer = setTimeout(async () => {
+    clearInterval(tick);
+    if (cancelled) return;
+    dismissToast(toast);
+    try {
+      const result = await commit();
+      if (result && result.success === false) {
+        showToast(`Failed: ${result.error || 'unknown error'}`, { type: 'error', duration: 5000 });
+        if (opts.onError) opts.onError(result.error);
+      }
+    } catch (err) {
+      showToast(`Failed: ${err.message || err}`, { type: 'error', duration: 5000 });
+      if (opts.onError) opts.onError(err);
+    }
+  }, delay);
+
+  undoBtn.addEventListener('click', () => {
+    cancelled = true;
+    clearTimeout(timer);
+    clearInterval(tick);
+    dismissToast(toast);
+  });
+}

--- a/renderer/js/state.js
+++ b/renderer/js/state.js
@@ -7,13 +7,45 @@ const AppState = {
   lastUpdated: null,
   totalProcesses: 0,
   filter: '',
+  quickFilter: 'all', // 'all' | 'port' | 'idle'
   sortColumn: 'cpu',
   sortDirection: 'desc',
   collapsedGroups: new Set(['system']),
   expandedPids: new Map(), // pid -> { loading: bool, data: null | {...} }
+  expandedClusters: new Set(), // `${groupKey}:${name}` of expanded clusters
+  clusterMode: true, // collapse same-named processes into clusters
   listeners: [],
   history: new Map(),
   pinnedNames: new Set(),
+
+  setQuickFilter(value) {
+    this.quickFilter = value || 'all';
+    this.notify();
+  },
+
+  setClusterMode(value) {
+    this.clusterMode = !!value;
+    this.notify();
+  },
+
+  toggleClusterMode() {
+    this.clusterMode = !this.clusterMode;
+    this.notify();
+    return this.clusterMode;
+  },
+
+  toggleCluster(clusterKey) {
+    if (this.expandedClusters.has(clusterKey)) {
+      this.expandedClusters.delete(clusterKey);
+    } else {
+      this.expandedClusters.add(clusterKey);
+    }
+    this.notify();
+  },
+
+  isClusterExpanded(clusterKey) {
+    return this.expandedClusters.has(clusterKey);
+  },
 
   setPinned(names) {
     this.pinnedNames = new Set(Array.isArray(names) ? names : []);
@@ -104,17 +136,33 @@ const AppState = {
     return this.collapsedGroups.has(groupKey);
   },
 
+  _matchesQuickFilter(p) {
+    switch (this.quickFilter) {
+      case 'port':
+        return p.ports && p.ports.length > 0;
+      case 'idle':
+        // Likely-abandoned: no listening port and effectively no CPU.
+        return (!p.ports || p.ports.length === 0) && p.cpu < 1;
+      default:
+        return true;
+    }
+  },
+
+  _matchesTextFilter(p) {
+    if (!this.filter) return true;
+    return (
+      p.name.toLowerCase().includes(this.filter) ||
+      p.pid.toString().includes(this.filter) ||
+      (p.ports && p.ports.some((port) => port.toString().includes(this.filter)))
+    );
+  },
+
   getFilteredGroups() {
     const result = {};
     for (const [key, group] of Object.entries(this.groups)) {
-      const filtered = this.filter
-        ? group.processes.filter(
-            (p) =>
-              p.name.toLowerCase().includes(this.filter) ||
-              p.pid.toString().includes(this.filter) ||
-              (p.ports && p.ports.some((port) => port.toString().includes(this.filter)))
-          )
-        : group.processes;
+      const filtered = group.processes.filter(
+        (p) => this._matchesTextFilter(p) && this._matchesQuickFilter(p)
+      );
 
       const sorted = this._sortProcesses(filtered);
       result[key] = { ...group, processes: sorted };

--- a/renderer/js/utils/reconcile.js
+++ b/renderer/js/utils/reconcile.js
@@ -1,0 +1,39 @@
+/**
+ * Keyed DOM reconciler.
+ *
+ * Instead of wiping a container and rebuilding it every poll (which destroys
+ * scroll position, hover state and replays animations — the "jank"), this
+ * updates existing elements in place, creates only genuinely new ones, removes
+ * stale ones, and reorders the survivors to match the desired order.
+ *
+ * @param {HTMLElement} parent
+ * @param {Array<{key: string, create: () => HTMLElement, update?: (el: HTMLElement) => void}>} items
+ */
+function reconcileChildren(parent, items) {
+  const existing = new Map();
+  for (const el of Array.from(parent.children)) {
+    if (el.__rkey != null) existing.set(el.__rkey, el);
+  }
+
+  const seen = new Set();
+  items.forEach((item, index) => {
+    seen.add(item.key);
+    let el = existing.get(item.key);
+    if (el) {
+      if (item.update) item.update(el);
+    } else {
+      el = item.create();
+      el.__rkey = item.key;
+    }
+    // Place el at position `index`. Comparing against the live children
+    // collection is safe because everything before `index` is already final.
+    const current = parent.children[index];
+    if (current !== el) {
+      parent.insertBefore(el, current || null);
+    }
+  });
+
+  for (const [key, el] of existing) {
+    if (!seen.has(key)) el.remove();
+  }
+}

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -1,9 +1,10 @@
 .process-group {
-  margin-bottom: 6px;
-  border-radius: var(--radius);
+  margin-bottom: 8px;
+  border-radius: var(--radius-lg);
   overflow: hidden;
   background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  border: 1px solid rgba(192, 202, 245, 0.06);
+  box-shadow: var(--shadow-sm);
 }
 
 .group-header {
@@ -85,11 +86,10 @@
 
 .group-body {
   overflow: hidden;
-  transition: max-height 0.3s ease;
 }
 
 .group-body.collapsed {
-  max-height: 0 !important;
+  display: none;
 }
 
 .process-table {
@@ -250,6 +250,189 @@
   padding: 1px 6px;
   border-radius: 3px;
   margin-left: 6px;
+}
+
+/* ── Quick-filter chips ───────────────────────────────── */
+.filter-chips {
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px 2px;
+  flex-shrink: 0;
+}
+
+.chip {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  padding: 3px 12px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all var(--transition-speed);
+}
+
+.chip:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.chip.chip-active {
+  background: rgba(122, 162, 247, 0.12);
+  border-color: var(--accent-blue);
+  color: var(--accent-blue);
+}
+
+.settings-btn.active {
+  border-color: var(--accent-blue);
+  color: var(--accent-blue);
+  background: rgba(122, 162, 247, 0.08);
+}
+
+/* ── Cluster rows ──────────────────────────────────────── */
+.cluster-row {
+  cursor: pointer;
+  background: rgba(122, 162, 247, 0.04);
+}
+
+.cluster-row:hover {
+  background: var(--bg-hover);
+}
+
+.cluster-name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.cluster-badge {
+  display: inline-block;
+  margin-left: 8px;
+  background: var(--accent-blue);
+  color: var(--bg-primary);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 0 6px;
+  border-radius: 8px;
+  font-family: var(--font-mono);
+}
+
+.cluster-row.warning-row .cluster-badge {
+  background: var(--accent-amber);
+}
+
+.cluster-pid {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.kill-btn-cluster {
+  white-space: nowrap;
+}
+
+.cluster-child .col-name {
+  padding-left: 26px;
+  color: var(--text-secondary);
+}
+
+.cluster-child {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+/* ── Toasts ────────────────────────────────────────────── */
+#toast-container {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 3000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 3px solid var(--accent-blue);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  font-size: 12px;
+  color: var(--text-primary);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  animation: toastIn 0.2s ease;
+  max-width: 360px;
+}
+
+.toast-leaving {
+  animation: toastOut 0.2s ease forwards;
+}
+
+.toast-pending {
+  border-left-color: var(--accent-red);
+}
+
+.toast-success {
+  border-left-color: var(--accent-green);
+}
+
+.toast-error {
+  border-left-color: var(--accent-red);
+}
+
+.toast-message {
+  flex: 1;
+  font-family: var(--font-mono);
+}
+
+.toast-countdown {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  min-width: 22px;
+  text-align: right;
+}
+
+.toast-undo {
+  background: transparent;
+  border: 1px solid var(--accent-blue);
+  color: var(--accent-blue);
+  padding: 2px 10px;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-speed);
+}
+
+.toast-undo:hover {
+  background: var(--accent-blue);
+  color: var(--bg-primary);
+}
+
+@keyframes toastIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes toastOut {
+  from { opacity: 1; transform: translateY(0); }
+  to { opacity: 0; transform: translateX(20px); }
+}
+
+/* ── Duplicate-warning setting row ─────────────────────── */
+.settings-dup-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.settings-dup-row .settings-threshold-input {
+  width: 70px;
 }
 
 /* Status bar */
@@ -748,7 +931,7 @@
   background: rgba(122, 162, 247, 0.08);
 }
 
-/* ── Toggle button ────────────────────────────────────── */
+/* ── Toggle switch (shadcn style) ─────────────────────── */
 .settings-toggle-row {
   display: flex;
   align-items: center;
@@ -761,29 +944,82 @@
 }
 
 .settings-toggle {
-  padding: 3px 10px;
-  border-radius: 3px;
-  font-size: 10px;
-  font-weight: 600;
+  position: relative;
+  width: 40px;
+  height: 22px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-tertiary);
   cursor: pointer;
-  border: 1px solid;
-  transition: all var(--transition-speed);
+  font-size: 0;
+  flex-shrink: 0;
+  transition: background var(--transition-speed), border-color var(--transition-speed);
+}
+
+.settings-toggle::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: transform 0.18s cubic-bezier(0.16, 1, 0.3, 1), background var(--transition-speed);
 }
 
 .settings-toggle.on {
-  background: rgba(158, 206, 106, 0.12);
-  border-color: rgba(158, 206, 106, 0.3);
-  color: var(--accent-green);
+  background: rgba(122, 162, 247, 0.3);
+  border-color: var(--accent-blue);
 }
 
-.settings-toggle.off {
+.settings-toggle.on::after {
+  transform: translateX(18px);
+  background: var(--accent-blue);
+}
+
+.settings-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--ring);
+}
+
+/* ── Window controls (frameless) ──────────────────────── */
+.win-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 8px;
+  -webkit-app-region: no-drag;
+}
+
+.win-btn {
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
-  border-color: var(--border-color);
-  color: var(--text-muted);
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-speed), color var(--transition-speed);
 }
 
-.settings-toggle:hover {
-  opacity: 0.85;
+.win-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.win-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.win-close:hover {
+  background: var(--accent-red);
+  color: #fff;
 }
 
 /* ── Custom rules ─────────────────────────────────────── */
@@ -862,6 +1098,7 @@
 
 .settings-rule-input:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px var(--ring);
 }
 
 .settings-rule-input.input-error {
@@ -915,6 +1152,7 @@
 
 .settings-threshold-input:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px var(--ring);
 }
 
 .settings-pinned-name {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -15,8 +15,13 @@
   --border-color: #292e42;
   --font-mono: 'Cascadia Code', 'JetBrains Mono', 'Consolas', 'Courier New', monospace;
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --radius: 6px;
-  --transition-speed: 0.2s;
+  --radius: 8px;
+  --radius-sm: 6px;
+  --radius-lg: 14px;
+  --ring: rgba(122, 162, 247, 0.45);
+  --shadow-lg: 0 24px 64px -16px rgba(0, 0, 0, 0.6);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.25);
+  --transition-speed: 0.15s;
 }
 
 *, *::before, *::after {
@@ -32,7 +37,9 @@ html, body {
 
 body {
   font-family: var(--font-sans);
-  background: var(--bg-primary);
+  /* Transparent so the window's Mica backdrop shows through the gaps around
+     our opaque cards. The header/status bar/cards keep solid backgrounds. */
+  background: transparent;
   color: var(--text-primary);
   font-size: 13px;
   line-height: 1.5;
@@ -49,7 +56,8 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 20px;
+  padding: 0 10px 0 20px;
+  min-height: 46px;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   -webkit-app-region: drag;
@@ -85,6 +93,7 @@ body {
 
 #filter-input:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px var(--ring);
 }
 
 #filter-input::placeholder {
@@ -97,21 +106,30 @@ main#process-groups {
   padding: 8px 12px;
 }
 
-main#process-groups::-webkit-scrollbar {
-  width: 8px;
+/* Refined, unobtrusive scrollbars everywhere (shadcn/macOS style) */
+::-webkit-scrollbar {
+  width: 11px;
+  height: 11px;
 }
 
-main#process-groups::-webkit-scrollbar-track {
-  background: var(--bg-primary);
+::-webkit-scrollbar-track {
+  background: transparent;
 }
 
-main#process-groups::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 4px;
-}
-
-main#process-groups::-webkit-scrollbar-thumb:hover {
+::-webkit-scrollbar-thumb {
   background: var(--text-muted);
+  border-radius: 999px;
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-secondary);
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 .hidden {
@@ -121,20 +139,35 @@ main#process-groups::-webkit-scrollbar-thumb:hover {
 .modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(13, 14, 22, 0.45);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  animation: modalFadeIn 0.15s ease;
+}
+
+@keyframes modalFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .modal-content {
   background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius);
+  border: 1px solid rgba(192, 202, 245, 0.08);
+  border-radius: var(--radius-lg);
   padding: 24px;
   min-width: 320px;
   text-align: center;
+  box-shadow: var(--shadow-lg);
+  animation: modalPop 0.16s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes modalPop {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
 }
 
 .modal-content p {


### PR DESCRIPTION
## What & why

Reworks the dashboard around its core use case — spotting and killing runaway agent-spawned processes (e.g. dozens of `node.exe` / `node_repl.exe`) — and gives it a more refined, less Windows-native look.

## Functionality

- **Diff-renderer** ([reconcile.js](renderer/js/utils/reconcile.js)) — replaces the `container.innerHTML = ''` full rebuild on every 3s poll. Rows are reused and updated in place, so scroll position, hover state and sparklines survive refreshes instead of flickering. This is the foundation for everything below.
- **Process clustering** — 3+ identically-named processes collapse into a single row with a count badge, aggregate CPU/RAM and a bulk **Kill N** button. Expand to see members. Toggle in the header or Settings; persisted as config `clusterProcesses` (default on).
- **Duplicate-inflation warnings** — `detectDuplicates` fires when N+ dev processes share a name (config `duplicateThreshold`, default 8), surfaced as a notification + status-bar warning + highlighted cluster.
- **Quick-filter chips** — All / With port / Idle.
- **Undo-toast kills** — the single Kill button now schedules a delayed kill with a 5s Undo toast instead of a blocking confirm modal (batch kills keep the confirm dialog).

## Window chrome

- **Frameless** window with custom minimal min/max/close controls (IPC-driven via preload), red-on-hover close, restore-icon swap, and double-click-to-maximize. Resizing still works via the Windows thick frame (aero-snap intact).
- **Windows 11 Mica** backdrop showing through a translucent `body`; header/status bar/cards stay opaque for readability.
- Native menu bar hidden (auto-hide); a minimal Edit/View menu is kept so clipboard + reload/devtools accelerators still work.

## Visual polish (shadcn/macOS)

Refined global scrollbars (the previously ugly native one in Settings is fixed), modal backdrop blur + soft shadows + pop-in, switch-style toggles, focus rings on inputs, softer card radii and shadows.

## Notes for reviewer

- Verified: `node --check` on all changed files + a unit test of `detectDuplicates`. The renderer/window chrome was iterated visually by the author via `pnpm dev` (Mica/frameless are Windows 11-specific).
- `pnpm-lock.yaml` / `pnpm-workspace.yaml` were intentionally left out of this PR — they're an unrelated package-manager change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)