### PR TITLE
Add "agents" classification group for AI coding agents

### DIFF
--- a/main/services/classifier.js
+++ b/main/services/classifier.js
@@ -1,5 +1,12 @@
 const GROUP_RULES = [
   {
+    group: 'agents',
+    icon: '🤖',
+    label: 'Agents',
+    match: (name) =>
+      /^(claude|aider|copilot|codex|cursor-agent|gemini)/i.test(name),
+  },
+  {
     group: 'dev',
     icon: '🟢',
     label: 'Dev Processes',
@@ -41,10 +48,11 @@ const PORT_GROUP_MAP = {
 
 const GROUP_META = {
   dev: { icon: '🟢', label: 'Dev Processes', order: 0 },
-  docker: { icon: '🐳', label: 'Docker', order: 1 },
-  databases: { icon: '🗄️', label: 'Databases', order: 2 },
-  apps: { icon: '🔵', label: 'Apps', order: 3 },
-  system: { icon: '⚙️', label: 'System', order: 4 },
+  agents: { icon: '🤖', label: 'Agents', order: 1 },
+  docker: { icon: '🐳', label: 'Docker', order: 2 },
+  databases: { icon: '🗄️', label: 'Databases', order: 3 },
+  apps: { icon: '🔵', label: 'Apps', order: 4 },
+  system: { icon: '⚙️', label: 'System', order: 5 },
 };
 
 const config = require('./config');

--- a/main/services/config.js
+++ b/main/services/config.js
@@ -24,7 +24,7 @@ const DEFAULTS = {
 };
 
 const VALID_THEMES = ['dark', 'light'];
-const VALID_GROUPS = ['dev', 'docker', 'databases', 'apps', 'system'];
+const VALID_GROUPS = ['dev', 'agents', 'docker', 'databases', 'apps', 'system'];
 
 let cache = null;
 

--- a/renderer/js/app.js
+++ b/renderer/js/app.js
@@ -2,7 +2,7 @@ let pollInterval = 3000; // will be overridden by config
 let hiddenPollInterval = 15000; // poll cadence while the window is hidden (overridden by config)
 let isHidden = false; // true while the window is hidden/minimized
 let pollTimer = null;
-const GROUP_ORDER = ['dev', 'docker', 'databases', 'apps', 'system'];
+const GROUP_ORDER = ['dev', 'agents', 'docker', 'databases', 'apps', 'system'];
 
 let refreshTimer = null;
 

--- a/renderer/js/components/settings.js
+++ b/renderer/js/components/settings.js
@@ -1,8 +1,9 @@
 /* Settings panel – rendered as a modal overlay */
 
-const VALID_GROUPS = ['dev', 'docker', 'databases', 'apps', 'system'];
+const VALID_GROUPS = ['dev', 'agents', 'docker', 'databases', 'apps', 'system'];
 const GROUP_LABELS = {
   dev: 'Dev Processes',
+  agents: 'Agents',
   docker: 'Docker',
   databases: 'Databases',
   apps: 'Apps',

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -1615,3 +1615,6 @@
   box-shadow: 0 0 4px rgba(247, 118, 142, 0.5);
   opacity: 1;
 }
+/* ── Agents group ─────────── */
+.group-agents .group-name { color: var(--accent-amber); }
+.group-color-agents { color: var(--accent-amber); }

--- a/test/classifier.test.js
+++ b/test/classifier.test.js
@@ -25,6 +25,7 @@ fs.writeFileSync(
 );
 
 const { classify, GROUP_META } = require('../main/services/classifier');
+const config = require('../main/services/config');
 
 test('classify groups dev tooling by process name', () => {
   assert.strictEqual(classify('node.exe', []), 'dev');
@@ -47,6 +48,16 @@ test('classify recognises docker, database, and app processes', () => {
   assert.strictEqual(classify('slack.exe', []), 'apps');
 });
 
+test('classify groups AI coding agents by process name', () => {
+  assert.strictEqual(classify('claude', []), 'agents');
+  assert.strictEqual(classify('Claude.exe', []), 'agents');
+  assert.strictEqual(classify('aider', []), 'agents');
+  assert.strictEqual(classify('copilot.exe', []), 'agents');
+  assert.strictEqual(classify('codex', []), 'agents');
+  assert.strictEqual(classify('cursor-agent', []), 'agents');
+  assert.strictEqual(classify('gemini', []), 'agents');
+});
+
 test('classify falls back to port-based classification', () => {
   assert.strictEqual(classify('unknown-binary', [5432]), 'databases');
   assert.strictEqual(classify('unknown-binary', [2375]), 'docker');
@@ -64,8 +75,21 @@ test('classify gives user-defined custom rules highest priority', () => {
   assert.strictEqual(classify('myapp-server.exe', [3000]), 'databases');
 });
 
+test('custom rules override the built-in agents group', () => {
+  // Without a matching custom rule, "claude" lands in agents.
+  assert.strictEqual(classify('claude', []), 'agents');
+  // A user rule targeting the same name must win over the built-in agents rule.
+  const original = config.get('customRules');
+  config.set('customRules', [...original, { pattern: '^claude', group: 'apps' }]);
+  try {
+    assert.strictEqual(classify('claude.exe', []), 'apps');
+  } finally {
+    config.set('customRules', original);
+  }
+});
+
 test('GROUP_META covers all classification targets', () => {
-  for (const group of ['dev', 'docker', 'databases', 'apps', 'system']) {
+  for (const group of ['dev', 'agents', 'docker', 'databases', 'apps', 'system']) {
     assert.ok(GROUP_META[group], `missing meta for ${group}`);
     assert.strictEqual(typeof GROUP_META[group].order, 'number');
   }


### PR DESCRIPTION
## Summary
- Adds a new process group `agents` that classifies AI coding agent binaries (claude, aider, copilot, codex, cursor-agent, gemini) by name pattern, case-insensitive, placed before the dev rules so agent binaries do not fall into `dev`. Their node/python children still classify as `dev` — intended.
- `GROUP_META` gains `agents` ordered right after `dev`; subsequent orders renumbered (no consumer reads the numeric order — renderer ordering is driven by `GROUP_ORDER`).
- `VALID_GROUPS` (main config + settings panel) and the settings custom-rule dropdown now accept/target `agents`, and the renderer renders the group after Dev Processes.
- CSS group accents (`.group-agents .group-name`, `.group-color-agents`) appended at end of components.css using `var(--accent-amber)` (purple was already taken by Databases; amber is defined in both themes).

## Testing
- `npm test` — 32 pass, including new cases: `claude`/`Claude.exe`/`aider` etc. → agents; custom rule still overrides the agents group; GROUP_META completeness including agents.
- `npm run lint` — clean.
- Smoke boot: `npm start` ran ~15 s with no uncaught exceptions or renderer errors (only benign GPU disk-cache warnings); process tree killed by PID afterwards.
