### PR TITLE
Add accumulated CPU cost per process

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ const utilGlobals = {
   formatCpu: 'writable',
   cpuClass: 'writable',
   formatPort: 'writable',
+  formatCpuSeconds: 'writable',
   // renderer/js/utils/reconcile.js
   reconcileChildren: 'writable',
 };

--- a/main/poll-manager.js
+++ b/main/poll-manager.js
@@ -5,6 +5,7 @@ const dockerCollector = require('./collectors/docker-collector');
 const { classify, GROUP_META } = require('./services/classifier');
 const { detect, detectThresholds, detectDuplicates } = require('./services/anomaly-detector');
 const config = require('./services/config');
+const cpuAccumulator = require('./services/cpu-accumulator');
 
 let busy = false;
 let lastSnapshot = null;
@@ -78,6 +79,9 @@ async function collectAll() {
     }
 
     // [anchor: enrichers] — per-process enrichment blocks go below this line
+
+    // Accumulate per-process CPU cost (attaches proc.cpuTimeSec)
+    cpuAccumulator.update(merged, Date.now());
 
     // Detect anomalies (port conflicts + resource thresholds)
     const warnings = detect(merged);

--- a/main/services/cpu-accumulator.js
+++ b/main/services/cpu-accumulator.js
@@ -1,0 +1,61 @@
+// Accumulates per-process CPU cost across polls: integrates the sampled
+// CPU percentage over wall-clock time into total CPU-seconds consumed,
+// so a process that burned 100% CPU for 5 minutes shows "5m" of CPU time
+// even if it is idle right now. Values are CPU-core-seconds: a process
+// pinning multiple cores reports cpu > 100 and accumulates faster than
+// wall clock, like the user+sys total of `time`. Pure Node module — no
+// Electron imports.
+
+const cpuTimes = new Map(); // pid -> { cpuSeconds, lastTs, started }
+
+// Intervals longer than this are not integrated: the sampled cpu% only
+// describes recent activity, so integrating it across a system sleep or
+// a wall-clock jump would fabricate CPU cost. The entry is re-baselined
+// at the new timestamp instead.
+const MAX_ELAPSED_SEC = 300;
+
+/**
+ * Update accumulated CPU time for each process and attach it as
+ * `proc.cpuTimeSec`. First sighting of a pid records a baseline only
+ * (no elapsed interval to integrate over yet). A pid whose start time
+ * changed is treated as a new process (the OS reused the pid).
+ */
+function update(processes, nowTs) {
+  const activePids = new Set();
+
+  for (const proc of processes) {
+    activePids.add(proc.pid);
+    let entry = cpuTimes.get(proc.pid);
+    if (entry && entry.started !== proc.started) {
+      // Same pid, different start time: pid was recycled for a new
+      // process, so the banked total belongs to a dead one. Start over.
+      entry = null;
+    }
+    if (!entry) {
+      entry = { cpuSeconds: 0, lastTs: nowTs, started: proc.started };
+      cpuTimes.set(proc.pid, entry);
+    } else {
+      const elapsedSeconds = (nowTs - entry.lastTs) / 1000;
+      const cpu = Number.isFinite(proc.cpu) ? proc.cpu : 0;
+      // Skip negative intervals (clock stepped backwards) and implausibly
+      // long ones (sleep/resume, clock jump); re-baseline either way.
+      if (elapsedSeconds > 0 && elapsedSeconds <= MAX_ELAPSED_SEC) {
+        entry.cpuSeconds += (cpu / 100) * elapsedSeconds;
+      }
+      entry.lastTs = nowTs;
+    }
+    proc.cpuTimeSec = entry.cpuSeconds;
+  }
+
+  // Clean up dead pids (same pattern as thresholdHits in anomaly-detector)
+  for (const pid of cpuTimes.keys()) {
+    if (!activePids.has(pid)) cpuTimes.delete(pid);
+  }
+}
+
+/** Clear all accumulated state (for tests). */
+function reset() {
+  cpuTimes.clear();
+}
+
+module.exports = { update, reset };

--- a/renderer/js/components/process-table.js
+++ b/renderer/js/components/process-table.js
@@ -2,13 +2,30 @@
 const CLUSTER_MIN = 3;
 
 // ── Detail row (expanded process) ──────────────────────────────
-function renderDetailContent(data) {
+function findProcInState(pid) {
+  for (const group of Object.values(AppState.groups)) {
+    for (const proc of group.processes) {
+      if (proc.pid === pid) return proc;
+    }
+  }
+  return null;
+}
+
+function renderDetailContent(data, pid) {
   const sections = [];
 
   // Command line
   sections.push(renderDetailSection('Command Line', data.commandLine
     ? h('code', { className: 'detail-code' }, data.commandLine)
     : h('span', { className: 'detail-empty' }, 'Not available')
+  ));
+
+  // Accumulated CPU time (enriched onto the proc snapshot by main)
+  const proc = findProcInState(pid);
+  sections.push(renderDetailSection('CPU time',
+    proc && typeof proc.cpuTimeSec === 'number'
+      ? h('span', {}, formatCpuSeconds(proc.cpuTimeSec))
+      : h('span', { className: 'detail-empty' }, 'Not available')
   ));
 
   // Network connections
@@ -92,7 +109,7 @@ function populateDetailRow(tr, pid) {
       h('span', { className: 'detail-error' }, 'Could not retrieve process details.'),
     ]));
   } else {
-    detailTd.appendChild(renderDetailContent(entry.data));
+    detailTd.appendChild(renderDetailContent(entry.data, pid));
   }
   tr.appendChild(detailTd);
 }
@@ -197,7 +214,10 @@ function populateRow(tr, proc, opts = {}) {
   }
   nameChildren.push(h('span', {}, proc.name));
 
-  const cpuCell = h('td', { className: `col-cpu ${cpuClass(proc.cpu)}` }, [
+  const cpuCell = h('td', {
+    className: `col-cpu ${cpuClass(proc.cpu)}`,
+    title: `Accumulated CPU time: ${formatCpuSeconds(proc.cpuTimeSec)}`,
+  }, [
     h('span', { className: 'cell-value' }, formatCpu(proc.cpu)),
     cpuSparkline,
   ]);

--- a/renderer/js/utils/format.js
+++ b/renderer/js/utils/format.js
@@ -37,3 +37,16 @@ function formatPort(ports) {
   if (ports.length <= 2) return ports.join(', ');
   return `${ports[0]}, ${ports[1]} +${ports.length - 2}`;
 }
+
+function formatCpuSeconds(sec) {
+  if (typeof sec !== 'number' || !isFinite(sec) || sec < 0) return '—';
+
+  const seconds = Math.floor(sec);
+  if (seconds >= 3600) {
+    // Floor to one decimal so 1h57m reads "1.9h", never a premature "2.0h"
+    const hours = Math.floor(seconds / 360) / 10;
+    return `${hours.toFixed(1)}h`;
+  }
+  if (seconds >= 60) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  return `${seconds}s`;
+}

--- a/test/cpu-accumulator.test.js
+++ b/test/cpu-accumulator.test.js
@@ -1,0 +1,143 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const { update, reset } = require('../main/services/cpu-accumulator');
+
+// The accumulator keeps per-PID state between calls; reset before each
+// test so accumulation from one test never leaks into the next.
+beforeEach(() => {
+  reset();
+});
+
+test('first sighting records a baseline of 0 CPU-seconds', () => {
+  const procs = [{ pid: 1, name: 'node.exe', cpu: 50 }];
+  update(procs, 1000);
+  assert.strictEqual(procs[0].cpuTimeSec, 0);
+});
+
+test('accumulates cpu% integrated over elapsed time across polls', () => {
+  let procs = [{ pid: 1, name: 'node.exe', cpu: 50 }];
+  update(procs, 0);
+
+  // 10 s at 50% => 5 CPU-seconds
+  procs = [{ pid: 1, name: 'node.exe', cpu: 50 }];
+  update(procs, 10_000);
+  assert.strictEqual(procs[0].cpuTimeSec, 5);
+
+  // + 20 s at 100% => 5 + 20 = 25 CPU-seconds
+  procs = [{ pid: 1, name: 'node.exe', cpu: 100 }];
+  update(procs, 30_000);
+  assert.strictEqual(procs[0].cpuTimeSec, 25);
+
+  // + 10 s at 0% => unchanged
+  procs = [{ pid: 1, name: 'node.exe', cpu: 0 }];
+  update(procs, 40_000);
+  assert.strictEqual(procs[0].cpuTimeSec, 25);
+});
+
+test('tracks multiple pids independently', () => {
+  update([
+    { pid: 1, name: 'a', cpu: 100 },
+    { pid: 2, name: 'b', cpu: 10 },
+  ], 0);
+
+  const procs = [
+    { pid: 1, name: 'a', cpu: 100 },
+    { pid: 2, name: 'b', cpu: 10 },
+  ];
+  update(procs, 10_000);
+  assert.strictEqual(procs[0].cpuTimeSec, 10);
+  assert.strictEqual(procs[1].cpuTimeSec, 1);
+});
+
+test('prunes state for dead pids so a reused pid starts fresh', () => {
+  update([{ pid: 1, name: 'a', cpu: 100 }], 0);
+  update([{ pid: 1, name: 'a', cpu: 100 }], 10_000); // 10 CPU-seconds banked
+
+  // pid 1 disappears for a poll -> its entry is pruned
+  update([{ pid: 2, name: 'b', cpu: 0 }], 20_000);
+
+  // pid 1 reappears: treated as a first sighting, no stale accumulation
+  const procs = [{ pid: 1, name: 'a', cpu: 100 }];
+  update(procs, 30_000);
+  assert.strictEqual(procs[0].cpuTimeSec, 0);
+});
+
+test('no NaN when cpu is 0, undefined, or non-finite', () => {
+  update([
+    { pid: 1, name: 'a', cpu: 0 },
+    { pid: 2, name: 'b' },
+    { pid: 3, name: 'c', cpu: NaN },
+  ], 0);
+
+  const procs = [
+    { pid: 1, name: 'a', cpu: 0 },
+    { pid: 2, name: 'b' },
+    { pid: 3, name: 'c', cpu: NaN },
+  ];
+  update(procs, 10_000);
+
+  for (const proc of procs) {
+    assert.ok(Number.isFinite(proc.cpuTimeSec), `pid ${proc.pid} produced ${proc.cpuTimeSec}`);
+    assert.strictEqual(proc.cpuTimeSec, 0);
+  }
+});
+
+test('a poll with identical timestamp does not change the total', () => {
+  update([{ pid: 1, name: 'a', cpu: 50 }], 0);
+  update([{ pid: 1, name: 'a', cpu: 50 }], 10_000);
+
+  const procs = [{ pid: 1, name: 'a', cpu: 50 }];
+  update(procs, 10_000); // zero elapsed time
+  assert.strictEqual(procs[0].cpuTimeSec, 5);
+});
+
+test('a recycled pid (changed start time) is treated as a new process', () => {
+  update([{ pid: 1, name: 'a', cpu: 100, started: 111 }], 0);
+  update([{ pid: 1, name: 'a', cpu: 100, started: 111 }], 10_000); // 10 CPU-seconds banked
+
+  // Same pid reappears within one poll gap but with a new start time:
+  // the OS reused the pid, so the banked total must not carry over.
+  const procs = [{ pid: 1, name: 'b', cpu: 0, started: 222 }];
+  update(procs, 20_000);
+  assert.strictEqual(procs[0].cpuTimeSec, 0);
+});
+
+test('implausibly long gaps (sleep/clock jump) are not integrated', () => {
+  update([{ pid: 1, name: 'a', cpu: 100 }], 0);
+  update([{ pid: 1, name: 'a', cpu: 100 }], 10_000); // 10 CPU-seconds banked
+
+  // 8 hours pass (laptop asleep): the gap is skipped, not billed.
+  let procs = [{ pid: 1, name: 'a', cpu: 100 }];
+  update(procs, 10_000 + 8 * 3600 * 1000);
+  assert.strictEqual(procs[0].cpuTimeSec, 10);
+
+  // Accumulation resumes from the re-baselined timestamp.
+  procs = [{ pid: 1, name: 'a', cpu: 100 }];
+  update(procs, 10_000 + 8 * 3600 * 1000 + 5000);
+  assert.strictEqual(procs[0].cpuTimeSec, 15);
+});
+
+test('a backwards clock step never subtracts or inflates the total', () => {
+  update([{ pid: 1, name: 'a', cpu: 100 }], 60_000);
+  update([{ pid: 1, name: 'a', cpu: 100 }], 70_000); // 10 CPU-seconds banked
+
+  // Clock steps back 60 s: negative interval is skipped.
+  let procs = [{ pid: 1, name: 'a', cpu: 100 }];
+  update(procs, 10_000);
+  assert.strictEqual(procs[0].cpuTimeSec, 10);
+
+  // Next poll measures from the re-baselined (stepped-back) timestamp.
+  procs = [{ pid: 1, name: 'a', cpu: 100 }];
+  update(procs, 15_000);
+  assert.strictEqual(procs[0].cpuTimeSec, 15);
+});
+
+test('reset clears all accumulated state', () => {
+  update([{ pid: 1, name: 'a', cpu: 100 }], 0);
+  update([{ pid: 1, name: 'a', cpu: 100 }], 10_000);
+  reset();
+
+  const procs = [{ pid: 1, name: 'a', cpu: 100 }];
+  update(procs, 20_000);
+  assert.strictEqual(procs[0].cpuTimeSec, 0);
+});


### PR DESCRIPTION
## Summary
- New `main/services/cpu-accumulator.js`: pure CommonJS module (no Electron imports) that integrates each process's sampled CPU% over poll intervals into accumulated CPU-core-seconds, keyed by pid. Handles pid recycling (start-time change re-baselines), clock steps and sleep/resume gaps (negative or >5 min intervals are skipped, not billed), and prunes dead pids each poll. Exports `reset()` for tests.
- `main/poll-manager.js`: one enricher block at the `[anchor: enrichers]` anchor attaching `proc.cpuTimeSec` to every merged process.
- `renderer/js/utils/format.js`: `formatCpuSeconds()` ("4m 12s", "2.1h"; hours floored to one decimal so 1h57m never reads "2.0h").
- `renderer/js/components/process-table.js`: tooltip on the CPU cell showing accumulated CPU time, and a "CPU time" section in the expanded detail panel (looked up from the live AppState snapshot by pid).
- `eslint.config.js`: registered the new `formatCpuSeconds` renderer global.
- `test/cpu-accumulator.test.js`: 10 tests covering accumulation, multi-pid independence, dead-pid pruning, pid reuse, long-gap/backwards-clock safety, NaN/undefined cpu, and reset.

## Why
A runaway agent process that burned the CPU for ten minutes and then went idle looks cheap in an instantaneous CPU% column. Accumulated CPU cost keeps it visible.

## Testing
- `npm test`: 40/40 pass (10 new)
- `npm run lint`: clean
- Smoke boot: app ran 15-20 s with no stderr output or renderer errors, process tree killed by PID afterwards
