### PR TITLE
Add "Kill process" action button to warning notifications

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -95,6 +95,34 @@ app.whenReady().then(() => {
   if (config.get('httpApiEnabled')) {
     httpApi.start({ getSnapshot: getLastSnapshot, port: config.get('httpApiPort') });
   }
+  // "Kill process" action button on warning notifications. On Windows the
+  // button activation may not be routed by Electron (see notifier.js caveat);
+  // when it is, kill the process and confirm with a small notification.
+  notifier.onAction((pid) => {
+    const pidNum = Number(pid);
+    if (!Number.isInteger(pidNum) || pidNum <= 0) return;
+    // Run inside a promise chain so a synchronous throw is captured too,
+    // and so this keeps working if kill() ever becomes async.
+    Promise.resolve()
+      .then(() => require('./services/process-killer').kill(pidNum))
+      .then((result) => {
+        const { Notification } = require('electron');
+        if (!Notification.isSupported()) return;
+        const n = new Notification(
+          result && result.success
+            ? { title: 'Process killed', body: `Killed ${pidNum}`, silent: true }
+            : {
+                title: 'Failed to kill process',
+                body: (result && result.error) || 'Unknown error',
+                silent: true,
+              }
+        );
+        n.show();
+      })
+      .catch((err) => {
+        console.error('Kill-from-notification failed:', err);
+      });
+  });
 });
 
 app.on('before-quit', () => {

--- a/main/services/notifier.js
+++ b/main/services/notifier.js
@@ -5,10 +5,47 @@ const MAX_NOTIFICATIONS_PER_POLL = 3;
 let enabled = true;
 let previousKeys = null; // null = first poll (skip notifications)
 let onClickCallback = null;
+let onActionCallback = null;
 
 function warningKey(w) {
   if (w.key) return w.key;
   return `${w.port}:${w.processName}`;
+}
+
+/**
+ * Escape a string for safe inclusion in XML text nodes and attribute values.
+ */
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Build the Windows toast XML for a warning notification with a
+ * "Kill process" action button. Pure function (no Electron dependency)
+ * so it can be unit-tested under plain Node.
+ *
+ * The button's `arguments` carry the pid (`action=kill&pid=<pid>`, XML-escaped)
+ * and the toast body's `launch` carries `action=focus&pid=<pid>` so that, when
+ * Electron routes the activation, we can tell the two apart.
+ */
+function buildToastXml(title, body, pid) {
+  const pidNum = Number(pid);
+  return (
+    `<toast activationType="foreground" launch="${xmlEscape(`action=focus&pid=${pidNum}`)}">` +
+    '<visual><binding template="ToastGeneric">' +
+    `<text>${xmlEscape(title)}</text>` +
+    `<text>${xmlEscape(body)}</text>` +
+    '</binding></visual>' +
+    '<actions>' +
+    `<action content="Kill process" activationType="foreground" arguments="${xmlEscape(`action=kill&pid=${pidNum}`)}"/>` +
+    '</actions>' +
+    '</toast>'
+  );
 }
 
 /**
@@ -52,15 +89,64 @@ function showNotification(warning) {
   else if (warning.key && warning.key.startsWith('mem:')) title = 'High memory usage';
   else if (warning.key && warning.key.startsWith('dup:')) title = 'Too many processes';
 
-  const n = new Notification({
-    title,
-    body: warning.message,
-    silent: false,
-  });
+  // Warnings that point at a single concrete process get a "Kill process"
+  // action button where the platform supports it.
+  //
+  // KNOWN CAVEAT (Windows): Electron's routing of toast *button* activations
+  // is unreliable without a registered protocol/AUMID activation handler —
+  // the 'action'/'click' events may simply never fire for the button on some
+  // setups. We wire every event Electron exposes ('action', plus 'click' for
+  // the toast body); if button events do not arrive in practice, the feature
+  // degrades gracefully to today's click-to-focus behavior, which is
+  // explicitly acceptable. The body click (Electron's 'click' event, fired on
+  // toast activation) keeps working as before.
+  //
+  // A kill button only makes sense for warnings about one concrete process.
+  // "dup:" warnings carry a representative pid plus a pids[] array; killing
+  // just one of N runaways while confirming "Killed <pid>" would be
+  // misleading, so those keep the plain notification.
+  const hasPid = Number.isInteger(warning.pid) && warning.pid > 0;
+  const killable = hasPid && !(Array.isArray(warning.pids) && warning.pids.length > 1);
+
+  let n;
+  if (process.platform === 'win32' && killable) {
+    // toastXml replaces {title, body}; the XML carries the same text plus
+    // the action button. Body click still emits Electron's 'click' event.
+    n = new Notification({
+      toastXml: buildToastXml(title, warning.message, warning.pid),
+      silent: false,
+    });
+  } else if (process.platform === 'darwin' && killable) {
+    // macOS supports action buttons natively via the `actions` option; the
+    // button press arrives as the 'action' event.
+    n = new Notification({
+      title,
+      body: warning.message,
+      silent: false,
+      actions: [{ type: 'button', text: 'Kill process' }],
+    });
+  } else {
+    // Linux, or warnings without a single concrete pid: plain notification,
+    // same as before.
+    n = new Notification({
+      title,
+      body: warning.message,
+      silent: false,
+    });
+  }
 
   n.on('click', () => {
     if (onClickCallback) {
       onClickCallback(warning.pid);
+    }
+  });
+
+  // Fires when the user presses the "Kill process" button (macOS 'action';
+  // on Windows, only if Electron manages to route the button activation —
+  // see caveat above).
+  n.on('action', () => {
+    if (onActionCallback && killable) {
+      onActionCallback(warning.pid);
     }
   });
 
@@ -102,4 +188,14 @@ function onClick(cb) {
   onClickCallback = cb;
 }
 
-module.exports = { notify, setEnabled, isEnabled, onClick };
+/**
+ * Register a callback that is invoked with the PID when the user presses a
+ * notification's "Kill process" action button. Mirrors onClick. See the
+ * caveat in showNotification: on Windows the button activation may never be
+ * routed to us, in which case this callback simply never fires.
+ */
+function onAction(cb) {
+  onActionCallback = cb;
+}
+
+module.exports = { notify, setEnabled, isEnabled, onClick, onAction, buildToastXml };

--- a/test/notifier.test.js
+++ b/test/notifier.test.js
@@ -1,0 +1,197 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const Module = require('node:module');
+
+// notifier.js requires Electron's Notification at load time. Stub the
+// electron module with a fake Notification class so the module can be
+// tested under plain Node (CI has no Electron binary).
+const createdNotifications = [];
+
+class FakeNotification {
+  constructor(options) {
+    this.options = options;
+    this.handlers = {};
+    this.shown = false;
+    createdNotifications.push(this);
+  }
+
+  static isSupported() {
+    return true;
+  }
+
+  on(event, cb) {
+    this.handlers[event] = cb;
+  }
+
+  show() {
+    this.shown = true;
+  }
+}
+
+const originalLoad = Module._load;
+Module._load = function (request, ...rest) {
+  if (request === 'electron') {
+    return { Notification: FakeNotification };
+  }
+  return originalLoad.call(this, request, ...rest);
+};
+
+const notifier = require('../main/services/notifier');
+
+// ---------------------------------------------------------------------------
+// buildToastXml (pure function)
+// ---------------------------------------------------------------------------
+
+test('buildToastXml produces well-formed toast XML with the pid embedded', () => {
+  const xml = notifier.buildToastXml('High CPU usage', 'node is at 97% CPU', 123);
+
+  assert.ok(xml.startsWith('<toast '), 'starts with a <toast> root element');
+  assert.ok(xml.endsWith('</toast>'), 'ends with the closing </toast> tag');
+  assert.ok(xml.includes('<binding template="ToastGeneric">'), 'uses the ToastGeneric binding');
+  assert.ok(xml.includes('<text>High CPU usage</text>'), 'title becomes the first text node');
+  assert.ok(xml.includes('<text>node is at 97% CPU</text>'), 'body becomes the second text node');
+
+  // The action button carries the pid in its arguments (XML-escaped &).
+  assert.ok(xml.includes('content="Kill process"'), 'has a Kill process button');
+  assert.ok(
+    xml.includes('arguments="action=kill&amp;pid=123"'),
+    'button arguments carry action=kill and the pid'
+  );
+  assert.ok(
+    xml.includes('launch="action=focus&amp;pid=123"'),
+    'toast body launch arguments carry the pid'
+  );
+  assert.ok(xml.includes('activationType='), 'declares an activationType');
+
+  // Balanced tags for the elements we emit.
+  for (const tag of ['visual', 'binding', 'actions']) {
+    assert.ok(xml.includes(`<${tag}`), `has <${tag}>`);
+    assert.ok(xml.includes(`</${tag}>`), `closes </${tag}>`);
+  }
+
+  // No stray unescaped ampersands anywhere in the document.
+  assert.ok(!/&(?!(amp|lt|gt|quot|apos);)/.test(xml), 'every & is part of an entity');
+});
+
+test('buildToastXml escapes XML special characters in title and body', () => {
+  const xml = notifier.buildToastXml('a & b <c>', `"quoted" & 'apos' <tag>`, 42);
+
+  assert.ok(xml.includes('<text>a &amp; b &lt;c&gt;</text>'), 'title is escaped');
+  assert.ok(
+    xml.includes('<text>&quot;quoted&quot; &amp; &apos;apos&apos; &lt;tag&gt;</text>'),
+    'body is escaped'
+  );
+  // The injected <c> / <tag> must not appear as raw markup.
+  assert.ok(!xml.includes('<c>'), 'raw <c> is not present');
+  assert.ok(!xml.includes('<tag>'), 'raw <tag> is not present');
+  assert.ok(!/&(?!(amp|lt|gt|quot|apos);)/.test(xml), 'every & is part of an entity');
+});
+
+// ---------------------------------------------------------------------------
+// notify() dedupe / cap behavior (existing behavior, covered here)
+// ---------------------------------------------------------------------------
+
+// notifier keeps module-level state (previousKeys), so the notify() scenarios
+// run as one sequential test.
+test('notify seeds silently, dedupes by key, and caps per poll', () => {
+  const w = (key, pid) => ({ key, pid, message: `warning ${key}` });
+
+  // First poll: seed only, no notifications even though warnings exist.
+  notifier.notify([w('cpu:1', 1), w('mem:2', 2)]);
+  assert.strictEqual(createdNotifications.length, 0, 'first poll is silent');
+
+  // Same keys again: nothing new, nothing fired.
+  notifier.notify([w('cpu:1', 1), w('mem:2', 2)]);
+  assert.strictEqual(createdNotifications.length, 0, 'repeated keys are deduped');
+
+  // One new key alongside the old ones: exactly one notification.
+  notifier.notify([w('cpu:1', 1), w('mem:2', 2), w('dup:3', 3)]);
+  assert.strictEqual(createdNotifications.length, 1, 'only the new key fires');
+  assert.ok(createdNotifications[0].shown, 'notification was shown');
+
+  // A key that disappears and comes back counts as new again.
+  notifier.notify([w('cpu:1', 1)]);
+  assert.strictEqual(createdNotifications.length, 1, 'removals fire nothing');
+  notifier.notify([w('cpu:1', 1), w('dup:3', 3)]);
+  assert.strictEqual(createdNotifications.length, 2, 're-appearing key fires again');
+
+  // Five new keys at once: capped at 3 plus one summary notification.
+  createdNotifications.length = 0;
+  notifier.notify([
+    w('cpu:1', 1),
+    w('a:10', 10),
+    w('b:11', 11),
+    w('c:12', 12),
+    w('d:13', 13),
+    w('e:14', 14),
+  ]);
+  assert.strictEqual(createdNotifications.length, 4, '3 capped warnings + 1 summary');
+  const summary = createdNotifications[3];
+  assert.match(summary.options.body, /more conflict/, 'last notification is the summary');
+});
+
+// ---------------------------------------------------------------------------
+// onAction wiring
+// ---------------------------------------------------------------------------
+
+test('onAction callback receives the pid when the action event fires', () => {
+  const received = [];
+  notifier.onAction((pid) => received.push(pid));
+
+  createdNotifications.length = 0;
+  notifier.notify([{ key: 'cpu:999', pid: 999, message: 'runaway process' }]);
+  assert.strictEqual(createdNotifications.length, 1);
+
+  const n = createdNotifications[0];
+  assert.strictEqual(typeof n.handlers.action, 'function', 'action handler is wired');
+  n.handlers.action();
+  assert.deepStrictEqual(received, [999], 'callback got the pid');
+
+  // Body click still works as before.
+  const clicked = [];
+  notifier.onClick((pid) => clicked.push(pid));
+  n.handlers.click();
+  assert.deepStrictEqual(clicked, [999], 'click callback still receives the pid');
+});
+
+test('warnings without a numeric pid never trigger the action callback', () => {
+  const received = [];
+  notifier.onAction((pid) => received.push(pid));
+
+  createdNotifications.length = 0;
+  notifier.notify([{ key: 'port:5173', message: 'port conflict' }]);
+  assert.strictEqual(createdNotifications.length, 1);
+
+  const n = createdNotifications[0];
+  // Handler is wired but guarded: no pid, no callback.
+  n.handlers.action();
+  assert.deepStrictEqual(received, [], 'no pid means no action callback');
+  // No kill button either: never a toastXml or actions notification.
+  assert.strictEqual(n.options.toastXml, undefined);
+  assert.strictEqual(n.options.actions, undefined);
+});
+
+test('multi-process (dup) warnings do not get a single-pid kill action', () => {
+  const received = [];
+  notifier.onAction((pid) => received.push(pid));
+
+  createdNotifications.length = 0;
+  // Shape emitted by anomaly-detector.detectDuplicates: representative pid
+  // plus the full pids array. Killing one of N would be misleading.
+  notifier.notify([
+    { key: 'dup:node.exe', pid: 101, pids: [101, 102, 103], message: '3 node.exe processes' },
+  ]);
+  assert.strictEqual(createdNotifications.length, 1);
+
+  const n = createdNotifications[0];
+  assert.strictEqual(n.options.toastXml, undefined, 'no toast XML for dup warnings');
+  assert.strictEqual(n.options.actions, undefined, 'no macOS action button for dup warnings');
+  n.handlers.action();
+  assert.deepStrictEqual(received, [], 'action callback is suppressed for dup warnings');
+
+  // The body click still reports the representative pid, as before.
+  const clicked = [];
+  notifier.onClick((pid) => clicked.push(pid));
+  n.handlers.click();
+  assert.deepStrictEqual(clicked, [101]);
+});


### PR DESCRIPTION
## Summary

Warning notifications that point at a single concrete process now offer a **"Kill process"** action button where the platform supports it (Windows toast XML button, macOS native notification action). Pressing it kills the process via `process-killer` and shows a small confirmation notification.

## Changes

- **main/services/notifier.js**
  - New pure exported `buildToastXml(title, body, pid)` producing Windows toast XML with a "Kill process" action button; the button `arguments` carry `action=kill&pid=<pid>` (XML-escaped), the body `launch` carries `action=focus&pid=<pid>`. All dynamic content is XML-escaped.
  - On win32, warnings with a positive-integer `pid` are constructed with `{ toastXml }`; on macOS with native `actions: [{type:'button', text:'Kill process'}]` (the `'action'` event). Linux, warnings without a pid, and multi-process `dup:` warnings (which carry a representative `pid` plus a `pids[]` array — killing one of N would be misleading) keep the plain `{title, body}` path.
  - New `onAction(cb)` export mirroring `onClick(cb)`; invokes `cb(pid)` when a kill action fires.
  - `notify(warnings)` signature and dedupe/cap behavior are unchanged.
- **main/main.js**: appended an `onAction` block next to the existing `onClick` wiring — validates the pid is a positive integer, calls `process-killer.kill(pid)` inside a promise chain (with `.catch`, so a throw cannot become an unhandled rejection), and shows a "Killed <pid>" or error confirmation notification.
- **test/notifier.test.js** (new): unit tests for `buildToastXml` (valid structure, pid embedded, escaping of `& < > " '`), `notify()` dedupe/cap behavior across polls, and `onAction`/`onClick` wiring, with `electron` stubbed via the `Module._load` monkey-patch (runs on CI without the Electron binary).

## Known caveat

Electron's routing of Windows toast **button** activations is unreliable without a registered protocol/AUMID activation handler. The available events (`'action'`, `'click'`) are wired; if button events do not arrive in practice, the feature degrades gracefully to the existing click-to-focus behavior, which is explicitly acceptable. The notification body click keeps working as today.

## Testing

- `npm test`: 36/36 pass (7 new notifier tests), `npm run lint` clean.
- Smoke boot: app started via Electron, alive after 15 s, no uncaught exceptions or renderer errors on stderr (only benign GPU disk-cache lock messages from a concurrent instance).
