### PR TITLE
Add adaptive polling: slow down while the window is hidden

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -53,6 +53,18 @@ function createWindow() {
   mainWindow.on('maximize', () => mainWindow.webContents.send('window-state', true));
   mainWindow.on('unmaximize', () => mainWindow.webContents.send('window-state', false));
 
+  // Adaptive polling: tell the renderer when the window is hidden/shown so it
+  // can slow down its poll loop while not visible.
+  const sendVisibility = (visible) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('window-visibility', visible);
+    }
+  };
+  mainWindow.on('hide', () => sendVisibility(false));
+  mainWindow.on('minimize', () => sendVisibility(false));
+  mainWindow.on('show', () => sendVisibility(true));
+  mainWindow.on('restore', () => sendVisibility(true));
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/main/preload.js
+++ b/main/preload.js
@@ -25,4 +25,8 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.on('window-state', (_event, isMaximized) => callback(isMaximized));
   },
   // [anchor: feature methods] — new feature API methods go below this line
+  // ── Adaptive polling
+  onWindowVisibility: (callback) => {
+    ipcRenderer.on('window-visibility', (_e, visible) => callback(visible));
+  },
 });

--- a/main/services/config.js
+++ b/main/services/config.js
@@ -19,6 +19,7 @@ const DEFAULTS = {
   duplicateThreshold: 8,   // warn when N+ dev processes share a name (0/1 = disabled)
   clusterProcesses: true,  // collapse same-named processes into clusters in the UI
   // [anchor: feature keys] — new feature config keys go below this line
+  hiddenPollInterval: 15,  // seconds (5–120) — poll cadence while the window is hidden
 };
 
 const VALID_THEMES = ['dark', 'light'];
@@ -110,6 +111,9 @@ function validate(cfg) {
   });
 
   // [anchor: feature validation] — new feature validation clauses go below this line
+
+  // hiddenPollInterval: clamp to 5–120
+  result.hiddenPollInterval = Math.max(5, Math.min(120, Number(result.hiddenPollInterval) || DEFAULTS.hiddenPollInterval));
 
   return result;
 }

--- a/renderer/js/app.js
+++ b/renderer/js/app.js
@@ -1,4 +1,6 @@
 let pollInterval = 3000; // will be overridden by config
+let hiddenPollInterval = 15000; // poll cadence while the window is hidden (overridden by config)
+let isHidden = false; // true while the window is hidden/minimized
 let pollTimer = null;
 const GROUP_ORDER = ['dev', 'docker', 'databases', 'apps', 'system'];
 
@@ -93,7 +95,7 @@ function render() {
 // Update "last refresh" timer every second
 function startRefreshTimer() {
   refreshTimer = setInterval(() => {
-    if (AppState.lastUpdated) {
+    if (!isHidden && AppState.lastUpdated) {
       renderStatusBar();
     }
   }, 1000);
@@ -208,8 +210,13 @@ function updateClusterBtn() {
 
 function startPolling() {
   if (pollTimer) clearInterval(pollTimer);
-  poll();
-  pollTimer = setInterval(poll, pollInterval);
+  // Skip the immediate poll when the data is still fresh (e.g. rapid
+  // minimize/restore cycles) — the interval below keeps it up to date.
+  if (!AppState.lastUpdated || Date.now() - AppState.lastUpdated >= pollInterval) {
+    poll();
+  }
+  // Hidden cadence never beats the visible one (config allows e.g. 5s hidden / 10s visible).
+  pollTimer = setInterval(poll, isHidden ? Math.max(hiddenPollInterval, pollInterval) : pollInterval);
 }
 
 // Init
@@ -220,6 +227,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   try {
     const cfg = await window.api.getConfig();
     pollInterval = (cfg.pollInterval || 3) * 1000;
+    hiddenPollInterval = (cfg.hiddenPollInterval || 15) * 1000;
     applyTheme(cfg.theme);
     AppState.profiles = cfg.profiles || [];
     AppState.setPinned(cfg.pinnedNames || []);
@@ -271,8 +279,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     updateClusterBtn();
 
     const newInterval = (cfg.pollInterval || 3) * 1000;
-    if (newInterval !== pollInterval) {
-      pollInterval = newInterval;
+    const newHiddenInterval = (cfg.hiddenPollInterval || 15) * 1000;
+    // Only restart the loop when the interval for the CURRENT visibility
+    // state changed — the other one is picked up on the next hide/show.
+    const activeChanged = isHidden
+      ? newHiddenInterval !== hiddenPollInterval
+      : newInterval !== pollInterval;
+    pollInterval = newInterval;
+    hiddenPollInterval = newHiddenInterval;
+    if (activeChanged) {
       startPolling();
     }
 
@@ -284,6 +299,26 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Global keyboard shortcuts
   document.addEventListener('keydown', handleGlobalKeys);
+
+  // Adaptive polling: slow the poll loop down while the window is hidden or
+  // minimized, and refresh immediately when it becomes visible again.
+  const handleVisibility = (visible) => {
+    const nowHidden = !visible;
+    if (nowHidden === isHidden) return;
+    isHidden = nowHidden;
+    startPolling(); // picks the cadence from isHidden; polls now only if stale
+  };
+  if (window.api.onWindowVisibility) {
+    window.api.onWindowVisibility(handleVisibility);
+  }
+  // Fallback: page visibility mirrors window hide/show in most cases.
+  document.addEventListener('visibilitychange', () => {
+    handleVisibility(document.visibilityState === 'visible');
+  });
+  // Initial sync — a hide/minimize that happened before these listeners were
+  // registered (e.g. app launched minimized, or hidden during the config
+  // await above) would otherwise be missed; startPolling() below picks it up.
+  isHidden = document.visibilityState === 'hidden';
 
   // Start polling
   startPolling();


### PR DESCRIPTION
## Summary
- The dashboard no longer burns CPU polling every 3 s while minimized to tray: the main window now emits a `window-visibility` IPC on `hide`/`minimize`/`show`/`restore` (guarded against destroyed windows), exposed to the renderer as `window.api.onWindowVisibility`.
- New config key `hiddenPollInterval` (default 15 s, clamped 5-120, config-file-only by design — no settings UI) controls the poll cadence while hidden; the effective hidden cadence is floored at the visible cadence.
- The renderer poll loop switches cadence via a module-level `isHidden` flag: `startPolling()` picks the interval from the flag and skips the immediate poll when data is still fresh, so rapid minimize/restore cycles do not trigger extra process scans; becoming visible refreshes immediately when stale.
- `document.visibilitychange` fallback plus an initial-state sync cover edges missed before listeners register (e.g. app launched minimized).
- `config-changed` keeps both intervals updated live but only restarts the loop when the interval for the current visibility state changed.
- The 1 s status-bar refresh timer is paused while hidden.

## Testing
- `npm test`: 30/30 pass
- `npm run lint`: clean
- Smoke boot: `npm start`, alive after ~18 s, stderr shows only pre-existing benign GPU-cache contention from a concurrently running instance; no uncaught exceptions or renderer errors.
