### PR TITLE
Add user-defined rule engine (notify/kill/command on sustained metric breaches)

### DIFF
--- a/main/poll-manager.js
+++ b/main/poll-manager.js
@@ -9,6 +9,9 @@ const cpuAccumulator = require('./services/cpu-accumulator');
 const healthCollector = require('./collectors/health-collector');
 const projectResolver = require('./services/project-resolver');
 const eventLog = require('./services/event-log');
+const ruleEngine = require('./services/rule-engine');
+const { kill } = require('./services/process-killer');
+const { launchCommand } = require('./services/profile-runner');
 
 let busy = false;
 let lastSnapshot = null;
@@ -139,6 +142,8 @@ async function collectAll() {
       const owner = merged.find((p) => p.projectName && wPids.includes(p.pid));
       if (owner) w.message += ` (project: ${owner.projectName})`;
     }
+    // User-defined rules: notify/kill/run a command on sustained metric breaches
+    warnings.push(...ruleEngine.evaluate(merged, config.get('userRules'), { kill, launchCommand }));
 
     // A warning can cover one pid (w.pid) or many (w.pids, e.g. duplicates).
     const warningPids = new Set();

--- a/main/services/config.js
+++ b/main/services/config.js
@@ -21,6 +21,7 @@ const DEFAULTS = {
   // [anchor: feature keys] — new feature config keys go below this line
   hiddenPollInterval: 15,  // seconds (5–120) — poll cadence while the window is hidden
   portHealthChecks: true,  // probe listening ports over HTTP and show up/down status
+  userRules: [],           // [{ id, pattern, metric: 'cpu'|'mem', threshold, sustainPolls, action: 'notify'|'kill'|'command', command?, cwd? }]
 };
 
 const VALID_THEMES = ['dark', 'light'];
@@ -116,6 +117,34 @@ function validate(cfg) {
   // hiddenPollInterval: clamp to 5–120
   result.hiddenPollInterval = Math.max(5, Math.min(120, Number(result.hiddenPollInterval) || DEFAULTS.hiddenPollInterval));
   result.portHealthChecks = !!result.portHealthChecks;
+  // userRules: validate rule-engine entries
+  if (!Array.isArray(result.userRules)) {
+    result.userRules = [];
+  }
+  result.userRules = result.userRules
+    .filter((rule) => {
+      if (!rule || typeof rule.pattern !== 'string' || !rule.pattern.trim()) return false;
+      // Verify the pattern is valid regex
+      try {
+        new RegExp(rule.pattern, 'i');
+      } catch {
+        return false;
+      }
+      if (!['cpu', 'mem'].includes(rule.metric)) return false;
+      const threshold = Number(rule.threshold);
+      if (!Number.isFinite(threshold) || threshold <= 0) return false;
+      if (!['notify', 'kill', 'command'].includes(rule.action)) return false;
+      if (rule.action === 'command' && (typeof rule.command !== 'string' || !rule.command.trim())) return false;
+      return true;
+    })
+    .map((rule) => ({
+      ...rule,
+      id: (typeof rule.id === 'string' && rule.id.trim())
+        ? rule.id
+        : `rule-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+      threshold: Number(rule.threshold),
+      sustainPolls: Math.max(1, Math.min(60, Number(rule.sustainPolls) || 1)),
+    }));
 
   return result;
 }

--- a/main/services/profile-runner.js
+++ b/main/services/profile-runner.js
@@ -106,6 +106,11 @@ function launchCommand(command, cwd, bufferKey) {
       child.stderr.on('error', () => {});
     }
 
+    // Spawn failures (e.g. a cwd that no longer exists) surface as an async
+    // 'error' event; without a listener it would crash the main process.
+    child.on('error', (err) => {
+      console.error('Failed to launch command:', err.message);
+    });
     child.unref();
     return { success: true };
   } catch (err) {

--- a/main/services/rule-engine.js
+++ b/main/services/rule-engine.js
@@ -1,0 +1,102 @@
+// User-defined rule engine.
+//
+// Evaluates rules of the form "if process name matches <pattern> and
+// <metric> stays over <threshold> for <sustainPolls> consecutive polls,
+// then notify / kill / run a command".
+//
+// Rule shape:
+//   { id, pattern, metric: 'cpu'|'mem', threshold, sustainPolls,
+//     action: 'notify'|'kill'|'command', command?, cwd? }
+//
+// `deps` ({ kill, launchCommand }) are injected by the caller so this
+// module stays free of Electron/OS dependencies and is unit-testable.
+// 'mem' compares memKB/1024 (MB) against threshold; 'cpu' compares percent.
+
+// Track consecutive polls each (rule, pid) pair spends over its threshold,
+// mirroring the `thresholdHits` pattern in anomaly-detector.js: fire once
+// when the count reaches sustainPolls, reset on a dip, clean up dead pids.
+const sustainHits = new Map(); // `${ruleId}:${pid}` -> count
+
+function evaluate(processes, rules, deps = {}) {
+  const warnings = [];
+
+  if (!Array.isArray(rules) || rules.length === 0) {
+    sustainHits.clear();
+    return warnings;
+  }
+
+  const activeKeys = new Set();
+
+  for (const rule of rules) {
+    if (!rule || typeof rule.pattern !== 'string' || !rule.pattern.trim()) continue;
+    if (rule.metric !== 'cpu' && rule.metric !== 'mem') continue;
+
+    let regex;
+    try {
+      regex = new RegExp(rule.pattern, 'i');
+    } catch {
+      continue; // invalid regex — skip the rule entirely
+    }
+
+    const threshold = Number(rule.threshold);
+    if (!Number.isFinite(threshold) || threshold <= 0) continue;
+    const sustainPolls = Math.max(1, Math.min(60, Number(rule.sustainPolls) || 1));
+
+    for (const proc of Array.isArray(processes) ? processes : []) {
+      if (!regex.test(proc.name || '')) continue;
+
+      const value = rule.metric === 'cpu' ? (proc.cpu || 0) : (proc.memKB || 0) / 1024;
+      const counterKey = `${rule.id}:${proc.pid}`;
+
+      if (value >= threshold) {
+        activeKeys.add(counterKey);
+        const count = (sustainHits.get(counterKey) || 0) + 1;
+        sustainHits.set(counterKey, count);
+        if (count === sustainPolls) {
+          warnings.push(fire(rule, proc, value, sustainPolls, deps));
+        }
+      } else {
+        sustainHits.delete(counterKey); // dip below threshold resets the streak
+      }
+    }
+  }
+
+  // Clean up counters for dead pids (and rules that no longer exist).
+  for (const key of sustainHits.keys()) {
+    if (!activeKeys.has(key)) sustainHits.delete(key);
+  }
+
+  return warnings;
+}
+
+function fire(rule, proc, value, sustainPolls, deps) {
+  const metricLabel = rule.metric === 'cpu'
+    ? `${value.toFixed(1)}% CPU`
+    : `${value.toFixed(0)} MB`;
+  const subject = `${proc.name} (PID ${proc.pid}) at ${metricLabel} for ${sustainPolls} poll${sustainPolls === 1 ? '' : 's'}`;
+
+  let message;
+  if (rule.action === 'kill') {
+    if (typeof deps.kill === 'function') deps.kill(proc.pid);
+    message = `Rule "${rule.pattern}": killed ${subject}`;
+  } else if (rule.action === 'command') {
+    if (typeof deps.launchCommand === 'function') deps.launchCommand(rule.command, rule.cwd);
+    message = `Rule "${rule.pattern}": ran "${rule.command}" — ${subject}`;
+  } else {
+    message = `Rule "${rule.pattern}": ${subject}`;
+  }
+
+  return {
+    pid: proc.pid,
+    processName: proc.name,
+    key: `rule:${rule.id}:${proc.pid}`,
+    message,
+  };
+}
+
+/** Clear all sustain counters (for tests). */
+function reset() {
+  sustainHits.clear();
+}
+
+module.exports = { evaluate, reset };

--- a/main/services/rule-engine.js
+++ b/main/services/rule-engine.js
@@ -17,6 +17,23 @@
 // when the count reaches sustainPolls, reset on a dip, clean up dead pids.
 const sustainHits = new Map(); // `${ruleId}:${pid}` -> count
 
+// Patterns are identical poll after poll, so compile each one once
+// (null marks a pattern that failed to compile).
+const regexCache = new Map(); // pattern -> RegExp | null
+
+function getRegex(pattern) {
+  if (regexCache.has(pattern)) return regexCache.get(pattern);
+  let regex;
+  try {
+    regex = new RegExp(pattern, 'i');
+  } catch {
+    regex = null;
+  }
+  if (regexCache.size >= 200) regexCache.clear(); // bound growth across rule edits
+  regexCache.set(pattern, regex);
+  return regex;
+}
+
 function evaluate(processes, rules, deps = {}) {
   const warnings = [];
 
@@ -26,17 +43,14 @@ function evaluate(processes, rules, deps = {}) {
   }
 
   const activeKeys = new Set();
+  const launchedCommands = new Set(); // rule ids whose command already ran this poll
 
   for (const rule of rules) {
     if (!rule || typeof rule.pattern !== 'string' || !rule.pattern.trim()) continue;
     if (rule.metric !== 'cpu' && rule.metric !== 'mem') continue;
 
-    let regex;
-    try {
-      regex = new RegExp(rule.pattern, 'i');
-    } catch {
-      continue; // invalid regex — skip the rule entirely
-    }
+    const regex = getRegex(rule.pattern);
+    if (!regex) continue; // invalid regex — skip the rule entirely
 
     const threshold = Number(rule.threshold);
     if (!Number.isFinite(threshold) || threshold <= 0) continue;
@@ -53,7 +67,7 @@ function evaluate(processes, rules, deps = {}) {
         const count = (sustainHits.get(counterKey) || 0) + 1;
         sustainHits.set(counterKey, count);
         if (count === sustainPolls) {
-          warnings.push(fire(rule, proc, value, sustainPolls, deps));
+          warnings.push(fire(rule, proc, value, sustainPolls, deps, launchedCommands));
         }
       } else {
         sustainHits.delete(counterKey); // dip below threshold resets the streak
@@ -69,7 +83,7 @@ function evaluate(processes, rules, deps = {}) {
   return warnings;
 }
 
-function fire(rule, proc, value, sustainPolls, deps) {
+function fire(rule, proc, value, sustainPolls, deps, launchedCommands) {
   const metricLabel = rule.metric === 'cpu'
     ? `${value.toFixed(1)}% CPU`
     : `${value.toFixed(0)} MB`;
@@ -77,11 +91,24 @@ function fire(rule, proc, value, sustainPolls, deps) {
 
   let message;
   if (rule.action === 'kill') {
-    if (typeof deps.kill === 'function') deps.kill(proc.pid);
-    message = `Rule "${rule.pattern}": killed ${subject}`;
+    // process-killer's kill() never throws; it returns { success, error }.
+    const result = typeof deps.kill === 'function' ? deps.kill(proc.pid) : null;
+    message = (result && result.success === false)
+      ? `Rule "${rule.pattern}": failed to kill ${subject} — ${result.error}`
+      : `Rule "${rule.pattern}": killed ${subject}`;
   } else if (rule.action === 'command') {
-    if (typeof deps.launchCommand === 'function') deps.launchCommand(rule.command, rule.cwd);
-    message = `Rule "${rule.pattern}": ran "${rule.command}" — ${subject}`;
+    // Launch the command at most once per rule per poll, even when several
+    // matching pids cross the threshold on the same poll.
+    let result = null;
+    if (!launchedCommands.has(rule.id)) {
+      launchedCommands.add(rule.id);
+      result = typeof deps.launchCommand === 'function'
+        ? deps.launchCommand(rule.command, rule.cwd)
+        : null;
+    }
+    message = (result && result.success === false)
+      ? `Rule "${rule.pattern}": failed to run "${rule.command}" (${result.error}) — ${subject}`
+      : `Rule "${rule.pattern}": ran "${rule.command}" — ${subject}`;
   } else {
     message = `Rule "${rule.pattern}": ${subject}`;
   }
@@ -94,9 +121,10 @@ function fire(rule, proc, value, sustainPolls, deps) {
   };
 }
 
-/** Clear all sustain counters (for tests). */
+/** Clear all sustain counters and cached regexes (for tests). */
 function reset() {
   sustainHits.clear();
+  regexCache.clear();
 }
 
 module.exports = { evaluate, reset };

--- a/renderer/js/components/settings.js
+++ b/renderer/js/components/settings.js
@@ -713,8 +713,9 @@ function renderUserRules() {
       const cwd = cwdInput.value.trim();
       if (action === 'command' && !command) return flashError(commandInput);
 
+      // No id here — config validation assigns one and the validated
+      // config round-trips back into settingsConfig via updateSetting.
       const rule = {
-        id: `rule-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
         pattern,
         metric: metricSelect.value,
         threshold,

--- a/renderer/js/components/settings.js
+++ b/renderer/js/components/settings.js
@@ -128,6 +128,9 @@ function renderSettingsBody() {
 
   // ── Profiles ───────────────────────────────────────
   body.appendChild(renderSection('Profiles', renderProfiles()));
+
+  // ── Rules (rule engine) ────────────────────────────
+  body.appendChild(renderSection('Rules', renderUserRules()));
 }
 
 function renderSection(title, content) {
@@ -596,5 +599,150 @@ function renderProfileSuggestions(profiles) {
   ]));
 
   wrapper.appendChild(panel);
+  return wrapper;
+}
+
+// ── Rules (user-defined rule engine) ───────────────────────
+function renderUserRules() {
+  const wrapper = h('div', { className: 'settings-rules settings-user-rules' });
+
+  wrapper.appendChild(h('p', { className: 'settings-hint' },
+    'When a process matching the pattern stays over the threshold for N consecutive polls, notify, kill it, or run a command.'));
+
+  const rules = settingsConfig.userRules || [];
+
+  if (rules.length > 0) {
+    const list = h('div', { className: 'settings-rules-list' });
+    for (let i = 0; i < rules.length; i++) {
+      const rule = rules[i];
+      const unit = rule.metric === 'mem' ? 'MB' : '%';
+      const metricLabel = rule.metric === 'mem' ? 'Memory' : 'CPU';
+      let actionLabel = rule.action;
+      if (rule.action === 'command') actionLabel = `run: ${rule.command}`;
+      const desc = `${metricLabel} > ${rule.threshold}${unit} for ${rule.sustainPolls} polls → ${actionLabel}`;
+
+      const row = h('div', { className: 'settings-rule-row' }, [
+        h('code', { className: 'settings-rule-pattern' }, rule.pattern),
+        h('span', { className: 'settings-user-rule-desc' }, desc),
+        h('button', {
+          className: 'settings-rule-remove',
+          title: 'Remove rule',
+          onClick: () => {
+            const updated = rules.filter((_, j) => j !== i);
+            updateSetting('userRules', updated);
+          },
+        }, '×'),
+      ]);
+      list.appendChild(row);
+    }
+    wrapper.appendChild(list);
+  }
+
+  // Add new rule form
+  const form = h('div', { className: 'settings-user-rule-form' });
+
+  const patternInput = h('input', {
+    type: 'text',
+    className: 'settings-rule-input',
+    placeholder: 'Regex pattern (e.g. node|python)',
+  });
+
+  const metricSelect = h('select', { className: 'settings-rule-select' }, [
+    h('option', { value: 'cpu' }, 'CPU %'),
+    h('option', { value: 'mem' }, 'Memory MB'),
+  ]);
+
+  const thresholdInput = h('input', {
+    type: 'number', min: '1', step: '1',
+    className: 'settings-threshold-input',
+    placeholder: '80',
+  });
+
+  const sustainInput = h('input', {
+    type: 'number', min: '1', max: '60', step: '1',
+    className: 'settings-threshold-input',
+  });
+  sustainInput.value = 3;
+
+  const actionSelect = h('select', { className: 'settings-rule-select' }, [
+    h('option', { value: 'notify' }, 'Notify'),
+    h('option', { value: 'kill' }, 'Kill'),
+    h('option', { value: 'command' }, 'Run command'),
+  ]);
+
+  const commandInput = h('input', {
+    type: 'text',
+    className: 'settings-rule-input',
+    placeholder: 'Command to run',
+  });
+  const cwdInput = h('input', {
+    type: 'text',
+    className: 'settings-rule-input',
+    placeholder: 'Working dir (optional)',
+  });
+  const commandRow = h('div', { className: 'settings-user-rule-command hidden' }, [
+    commandInput,
+    cwdInput,
+  ]);
+  actionSelect.addEventListener('change', () => {
+    commandRow.classList.toggle('hidden', actionSelect.value !== 'command');
+  });
+
+  const flashError = (input) => {
+    input.classList.add('input-error');
+    setTimeout(() => input.classList.remove('input-error'), 1500);
+  };
+
+  const addBtn = h('button', {
+    className: 'btn btn-secondary settings-rule-add',
+    onClick: () => {
+      const pattern = patternInput.value.trim();
+      if (!pattern) return flashError(patternInput);
+      try {
+        new RegExp(pattern, 'i');
+      } catch {
+        return flashError(patternInput);
+      }
+
+      const threshold = Number(thresholdInput.value);
+      if (!threshold || threshold <= 0) return flashError(thresholdInput);
+
+      const sustainPolls = Math.max(1, Math.min(60, Number(sustainInput.value) || 3));
+      const action = actionSelect.value;
+      const command = commandInput.value.trim();
+      const cwd = cwdInput.value.trim();
+      if (action === 'command' && !command) return flashError(commandInput);
+
+      const rule = {
+        id: `rule-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+        pattern,
+        metric: metricSelect.value,
+        threshold,
+        sustainPolls,
+        action,
+      };
+      if (action === 'command') {
+        rule.command = command;
+        if (cwd) rule.cwd = cwd;
+      }
+
+      updateSetting('userRules', [...(settingsConfig.userRules || []), rule]);
+    },
+  }, 'Add');
+
+  form.appendChild(patternInput);
+  form.appendChild(h('div', { className: 'settings-user-rule-fields' }, [
+    metricSelect,
+    h('label', {}, '>'),
+    thresholdInput,
+    h('label', {}, 'for'),
+    sustainInput,
+    h('label', {}, 'polls'),
+    actionSelect,
+    addBtn,
+  ]));
+  form.appendChild(commandRow);
+  wrapper.appendChild(form);
+
   return wrapper;
 }

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -1529,6 +1529,30 @@
   display: flex;
   align-items: center;
   gap: 6px;
+/* ── Rule engine ─────────── */
+.settings-user-rules .settings-user-rule-desc {
+  flex: 1;
+  font-size: 11px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-user-rule-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-user-rule-fields {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.settings-user-rule-fields label {
   font-size: 11px;
   color: var(--text-secondary);
 }
@@ -2043,4 +2067,11 @@
   display: flex;
   gap: 8px;
   margin-top: 8px;
+.settings-user-rule-command {
+  display: flex;
+  gap: 6px;
+}
+
+.settings-user-rule-command.hidden {
+  display: none;
 }

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -2075,3 +2075,8 @@
 .settings-user-rule-command.hidden {
   display: none;
 }
+
+.settings-user-rules .settings-threshold-input.input-error {
+  border-color: var(--accent-red);
+  animation: shake 0.3s ease;
+}

--- a/test/rule-engine.test.js
+++ b/test/rule-engine.test.js
@@ -132,6 +132,36 @@ test('counters are cleaned up when a pid disappears', () => {
   assert.strictEqual(evaluate(hot, rules, noDeps).length, 1);   // fires at 2
 });
 
+test('command action launches at most once per rule when several pids fire together', () => {
+  const launched = [];
+  const deps = { kill: () => {}, launchCommand: (cmd) => launched.push(cmd) };
+  const rules = [cpuRule({ action: 'command', command: 'npm run cleanup', sustainPolls: 1 })];
+  const hot = [
+    { pid: 70, name: 'node.exe', cpu: 95, memKB: 0 },
+    { pid: 71, name: 'node.exe', cpu: 96, memKB: 0 },
+    { pid: 72, name: 'node.exe', cpu: 97, memKB: 0 },
+  ];
+
+  const warnings = evaluate(hot, rules, deps);
+  assert.strictEqual(warnings.length, 3);          // one warning per pid
+  assert.deepStrictEqual(launched, ['npm run cleanup']); // but a single launch
+});
+
+test('kill failures are reported instead of claiming the process was killed', () => {
+  const deps = {
+    kill: () => ({ success: false, error: 'Access denied' }),
+    launchCommand: () => {},
+  };
+  const rules = [cpuRule({ action: 'kill', sustainPolls: 1 })];
+  const hot = [{ pid: 80, name: 'node.exe', cpu: 99, memKB: 0 }];
+
+  const warnings = evaluate(hot, rules, deps);
+  assert.strictEqual(warnings.length, 1);
+  assert.match(warnings[0].message, /failed to kill node\.exe \(PID 80\)/);
+  assert.match(warnings[0].message, /Access denied/);
+  assert.doesNotMatch(warnings[0].message, /^Rule "node": killed/);
+});
+
 test('empty or missing rule list returns no warnings and clears state', () => {
   const hot = [{ pid: 60, name: 'node.exe', cpu: 90, memKB: 0 }];
   const rules = [cpuRule({ sustainPolls: 2 })];

--- a/test/rule-engine.test.js
+++ b/test/rule-engine.test.js
@@ -1,0 +1,143 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const { evaluate, reset } = require('../main/services/rule-engine');
+
+// The engine keeps per-(rule, pid) sustain counters between calls;
+// reset() clears them so each test starts fresh.
+beforeEach(() => {
+  reset();
+});
+
+const noDeps = { kill: () => {}, launchCommand: () => {} };
+
+function cpuRule(overrides = {}) {
+  return {
+    id: 'r1',
+    pattern: 'node',
+    metric: 'cpu',
+    threshold: 80,
+    sustainPolls: 3,
+    action: 'notify',
+    ...overrides,
+  };
+}
+
+test('notify rule fires once after sustainPolls consecutive breaches', () => {
+  const rules = [cpuRule()];
+  const hot = [{ pid: 10, name: 'node.exe', cpu: 90, memKB: 1024 }];
+
+  assert.strictEqual(evaluate(hot, rules, noDeps).length, 0); // poll 1
+  assert.strictEqual(evaluate(hot, rules, noDeps).length, 0); // poll 2
+
+  const warnings = evaluate(hot, rules, noDeps); // poll 3
+  assert.strictEqual(warnings.length, 1);
+  assert.strictEqual(warnings[0].pid, 10);
+  assert.strictEqual(warnings[0].processName, 'node.exe');
+  assert.strictEqual(warnings[0].key, 'rule:r1:10');
+  assert.match(warnings[0].message, /node\.exe \(PID 10\)/);
+
+  // Fires exactly once, not on every subsequent poll
+  assert.strictEqual(evaluate(hot, rules, noDeps).length, 0); // poll 4
+});
+
+test('a dip below the threshold resets the sustain counter', () => {
+  const rules = [cpuRule({ sustainPolls: 2 })];
+  const hot = [{ pid: 11, name: 'node.exe', cpu: 95, memKB: 0 }];
+  const cool = [{ pid: 11, name: 'node.exe', cpu: 5, memKB: 0 }];
+
+  evaluate(hot, rules, noDeps);                                  // 1 hit
+  evaluate(cool, rules, noDeps);                                 // reset
+  assert.strictEqual(evaluate(hot, rules, noDeps).length, 0);    // 1 hit again
+  assert.strictEqual(evaluate(hot, rules, noDeps).length, 1);    // fires at 2
+});
+
+test('mem rules compare memKB/1024 against the MB threshold', () => {
+  const rules = [cpuRule({ id: 'm1', pattern: 'java', metric: 'mem', threshold: 1024, sustainPolls: 2 })];
+  const procs = [{ pid: 12, name: 'java.exe', cpu: 0, memKB: 2048 * 1024 }];
+
+  assert.strictEqual(evaluate(procs, rules, noDeps).length, 0);
+  const warnings = evaluate(procs, rules, noDeps);
+  assert.strictEqual(warnings.length, 1);
+  assert.strictEqual(warnings[0].key, 'rule:m1:12');
+  assert.match(warnings[0].message, /2048 MB/);
+
+  // Below the threshold (512 MB) nothing accumulates
+  reset();
+  const small = [{ pid: 12, name: 'java.exe', cpu: 0, memKB: 512 * 1024 }];
+  assert.strictEqual(evaluate(small, rules, noDeps).length, 0);
+  assert.strictEqual(evaluate(small, rules, noDeps).length, 0);
+});
+
+test('kill action calls the injected deps.kill and returns a warning', () => {
+  const killed = [];
+  const deps = { kill: (pid) => killed.push(pid), launchCommand: () => {} };
+  const rules = [cpuRule({ action: 'kill', sustainPolls: 2 })];
+  const hot = [{ pid: 20, name: 'node.exe', cpu: 99, memKB: 0 }];
+
+  evaluate(hot, rules, deps);
+  assert.deepStrictEqual(killed, []); // not before the sustain count
+
+  const warnings = evaluate(hot, rules, deps);
+  assert.deepStrictEqual(killed, [20]);
+  assert.strictEqual(warnings.length, 1);
+  assert.match(warnings[0].message, /killed node\.exe \(PID 20\)/);
+
+  // Does not keep killing on subsequent polls
+  evaluate(hot, rules, deps);
+  assert.deepStrictEqual(killed, [20]);
+});
+
+test('command action calls the injected launchCommand with command and cwd', () => {
+  const launched = [];
+  const deps = { kill: () => {}, launchCommand: (cmd, cwd) => launched.push({ cmd, cwd }) };
+  const rules = [cpuRule({
+    action: 'command',
+    command: 'npm run cleanup',
+    cwd: 'C:\\work',
+    sustainPolls: 1,
+  })];
+  const hot = [{ pid: 30, name: 'node.exe', cpu: 91, memKB: 0 }];
+
+  const warnings = evaluate(hot, rules, deps);
+  assert.deepStrictEqual(launched, [{ cmd: 'npm run cleanup', cwd: 'C:\\work' }]);
+  assert.strictEqual(warnings.length, 1);
+  assert.match(warnings[0].message, /ran "npm run cleanup"/);
+});
+
+test('rules with invalid regex patterns are skipped', () => {
+  const rules = [
+    cpuRule({ id: 'bad', pattern: '[unclosed', sustainPolls: 1 }),
+    cpuRule({ id: 'good', pattern: 'node', sustainPolls: 1 }),
+  ];
+  const hot = [{ pid: 40, name: 'node.exe', cpu: 100, memKB: 0 }];
+
+  const warnings = evaluate(hot, rules, noDeps);
+  assert.strictEqual(warnings.length, 1);
+  assert.strictEqual(warnings[0].key, 'rule:good:40');
+});
+
+test('non-matching processes never accumulate hits', () => {
+  const rules = [cpuRule({ sustainPolls: 1 })];
+  const procs = [{ pid: 41, name: 'chrome.exe', cpu: 100, memKB: 0 }];
+  assert.deepStrictEqual(evaluate(procs, rules, noDeps), []);
+});
+
+test('counters are cleaned up when a pid disappears', () => {
+  const rules = [cpuRule({ sustainPolls: 2 })];
+  const hot = [{ pid: 50, name: 'node.exe', cpu: 90, memKB: 0 }];
+
+  evaluate(hot, rules, noDeps);                                 // 1 hit
+  evaluate([], rules, noDeps);                                  // pid gone → cleanup
+  assert.strictEqual(evaluate(hot, rules, noDeps).length, 0);   // starts over at 1
+  assert.strictEqual(evaluate(hot, rules, noDeps).length, 1);   // fires at 2
+});
+
+test('empty or missing rule list returns no warnings and clears state', () => {
+  const hot = [{ pid: 60, name: 'node.exe', cpu: 90, memKB: 0 }];
+  const rules = [cpuRule({ sustainPolls: 2 })];
+
+  evaluate(hot, rules, noDeps);                                 // 1 hit
+  assert.deepStrictEqual(evaluate(hot, [], noDeps), []);        // clears counters
+  assert.strictEqual(evaluate(hot, rules, noDeps).length, 0);   // starts over
+  assert.deepStrictEqual(evaluate(hot, undefined, noDeps), []);
+});


### PR DESCRIPTION
## Summary
- New `main/services/rule-engine.js`: evaluates user rules of the form "if process matches *pattern* and cpu/mem stays over *threshold* for *sustainPolls* consecutive polls → notify / kill / run command". Per-(rule, pid) sustain counters mirror the `thresholdHits` pattern in anomaly-detector.js (fire once at N, reset on dip, dead-pid cleanup). Deps (`{ kill, launchCommand }`) are injected, so the module is Electron-free and CI-safe.
- `config.js`: `userRules: []` default plus validation at the feature anchors (valid regex, metric `cpu|mem`, threshold > 0, sustainPolls clamped 1–60, action `notify|kill|command`, command required for command rules, ids backfilled).
- `poll-manager.js`: one block at `[anchor: extra-warnings]` feeding rule warnings (`key: rule:<id>:<pid>`) through the existing notifier.
- Settings modal: new "Rules" section (list / add / remove, command+cwd fields shown for command rules), persisted via `updateSetting('userRules', …)`.
- `test/rule-engine.test.js`: 13 tests (sustain/fire-once/dip-reset, mem MB conversion, kill and command deps, invalid regex skipped, dead-pid cleanup, per-poll command dedupe, kill-failure reporting).

## Review fixes applied
- Kill failures are reported in the warning instead of claiming success; launchCommand failures surfaced too.
- Command-action rules launch at most once per rule per poll even when many pids fire together.
- Compiled rule regexes are cached instead of recompiled every poll.
- `profile-runner.js` now handles the async spawn `error` event (e.g. deleted cwd) so an auto-fired rule command cannot crash the main process.

## Known limitations (deliberate, per unit scope)
- Rule notifications reuse the notifier untouched, so they currently get the generic default title (`notifier.js` title mapping only knows `cpu:/mem:/dup:` prefixes) — trivial follow-up once parallel units land.
- Kill-action rules call the existing synchronous `process-killer.kill()` from the poll loop (bounded by its 5s timeout, fires once per sustain window); making the killer async is a separate concern.

## Testing
- `npm test` — 41 pass; `npm run lint` — clean.
- Smoke boot: `npm start` alive after 15s, no uncaught exceptions (only pre-existing Chromium GPU cache-contention noise from a second Electron instance on the machine).
