### PR TITLE
Add always-on-top Mini-HUD with global shortcut and tray toggle

### DIFF
--- a/main/hud-window.js
+++ b/main/hud-window.js
@@ -1,0 +1,73 @@
+const { app, BrowserWindow, screen } = require('electron');
+const path = require('path');
+
+// Mirrors tray-manager's minimize-to-tray pattern: the HUD's close button
+// hides the window (same as the toggle) instead of destroying it, except
+// when the app is actually quitting.
+let quitting = false;
+app.on('before-quit', () => {
+  quitting = true;
+});
+
+const HUD_WIDTH = 320;
+const HUD_HEIGHT = 220;
+const HUD_MARGIN = 12;
+
+let hudWindow = null;
+
+function createHud() {
+  const { workArea } = screen.getPrimaryDisplay();
+
+  hudWindow = new BrowserWindow({
+    width: HUD_WIDTH,
+    height: HUD_HEIGHT,
+    x: workArea.x + workArea.width - HUD_WIDTH - HUD_MARGIN,
+    y: workArea.y + HUD_MARGIN,
+    frame: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    resizable: false,
+    // A HUD should never steal focus (it would also become the parent for
+    // dialogs picked via getFocusedWindow). Clicks still work unfocused.
+    focusable: false,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  hudWindow.loadFile(path.join(__dirname, '..', 'renderer', 'hud.html'));
+
+  hudWindow.on('close', (event) => {
+    if (!quitting) {
+      event.preventDefault();
+      hudWindow.hide();
+    }
+  });
+
+  hudWindow.on('closed', () => {
+    hudWindow = null;
+  });
+}
+
+function toggleHud() {
+  if (!hudWindow) {
+    createHud();
+    return;
+  }
+  if (hudWindow.isVisible()) {
+    hudWindow.hide();
+  } else {
+    hudWindow.show();
+  }
+}
+
+function destroyHud() {
+  if (hudWindow) {
+    hudWindow.destroy();
+    hudWindow = null;
+  }
+}
+
+module.exports = { toggleHud, destroyHud };

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -257,6 +257,14 @@ function registerIpcHandlers() {
       return { success: false, error: err.message };
     }
   });
+
+  // ── Mini-HUD ─────────────────────────────────────────────────
+  // Read-only view of the latest snapshot: no collection, no notifier
+  // side-effects. The HUD polls this so it never races the main window's
+  // polling or consumes new-warning notifications.
+  ipcMain.handle('get-last-snapshot', () => {
+    return getLastSnapshot();
+  });
 }
 
 module.exports = { registerIpcHandlers };

--- a/main/main.js
+++ b/main/main.js
@@ -6,6 +6,8 @@ const notifier = require('./services/notifier');
 const config = require('./services/config');
 const httpApi = require('./services/http-api');
 const { getLastSnapshot } = require('./poll-manager');
+const { globalShortcut } = require('electron');
+const hudWindow = require('./hud-window');
 
 let mainWindow;
 
@@ -82,7 +84,9 @@ app.whenReady().then(() => {
   app.setLoginItemSettings({ openAtLogin: !!config.get('autostart') });
 
   notifier.onClick((pid) => {
-    if (!mainWindow) return;
+    // The app can be alive with no main window (closed to tray with the
+    // HUD open) — recreate it so notification clicks always land somewhere.
+    if (!mainWindow) createWindow();
     if (mainWindow.isMinimized()) mainWindow.restore();
     mainWindow.show();
     mainWindow.focus();
@@ -123,6 +127,14 @@ app.whenReady().then(() => {
         console.error('Kill-from-notification failed:', err);
       });
   });
+  // Mini-HUD global shortcut. Registration can fail when another instance
+  // (or app) already owns the accelerator — warn instead of crashing.
+  const hudShortcutRegistered = globalShortcut.register('CommandOrControl+Alt+L', () =>
+    hudWindow.toggleHud()
+  );
+  if (!hudShortcutRegistered) {
+    console.warn('Failed to register global shortcut CommandOrControl+Alt+L for the Mini-HUD');
+  }
 });
 
 app.on('before-quit', () => {
@@ -135,9 +147,12 @@ app.on('window-all-closed', () => {
 });
 
 app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
+  // Keyed on mainWindow (not getAllWindows) — the Mini-HUD is a second
+  // BrowserWindow, so a window-count check would fail to recreate the
+  // dashboard while the HUD is open.
+  if (mainWindow === null) {
     createWindow();
-  } else if (mainWindow) {
+  } else {
     mainWindow.show();
   }
 });
@@ -145,4 +160,6 @@ app.on('activate', () => {
 app.on('will-quit', () => {
   destroyTray();
   httpApi.stop();
+  globalShortcut.unregisterAll();
+  hudWindow.destroyHud();
 });

--- a/main/preload.js
+++ b/main/preload.js
@@ -43,4 +43,6 @@ contextBridge.exposeInMainWorld('api', {
 
   // ── Profile suggestions ──────────────────────────────────────
   scanProfileSuggestions: () => ipcRenderer.invoke('scan-profile-suggestions'),
+  // ── Mini-HUD
+  getLastSnapshot: () => ipcRenderer.invoke('get-last-snapshot'),
 });

--- a/main/tray-manager.js
+++ b/main/tray-manager.js
@@ -1,6 +1,7 @@
 const { app, Tray, Menu, nativeImage } = require('electron');
 const path = require('path');
 const config = require('./services/config');
+const { toggleHud } = require('./hud-window');
 
 let tray = null;
 let mainWindow = null;
@@ -19,6 +20,10 @@ function createTray(window) {
     {
       label: 'Show',
       click: showWindow,
+    },
+    {
+      label: 'Toggle Mini-HUD',
+      click: toggleHud,
     },
     { type: 'separator' },
     {

--- a/renderer/hud.html
+++ b/renderer/hud.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'">
+  <title>Localhost Mini-HUD</title>
+  <link rel="stylesheet" href="styles/main.css">
+  <link rel="stylesheet" href="styles/hud.css">
+</head>
+<body class="hud-body">
+  <div id="hud">
+    <header class="hud-header">
+      <span class="hud-title">Localhost HUD</span>
+      <span id="hud-warnings" class="hud-badge" title="Active warnings">0</span>
+      <button id="hud-close" class="hud-close" title="Hide" aria-label="Hide">
+        <svg viewBox="0 0 14 14" aria-hidden="true"><line x1="3.6" y1="3.6" x2="10.4" y2="10.4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="10.4" y1="3.6" x2="3.6" y2="10.4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+      </button>
+    </header>
+    <ul id="hud-list" class="hud-list"></ul>
+    <div id="hud-empty" class="hud-empty">Waiting for data&hellip;</div>
+  </div>
+  <script src="js/hud.js"></script>
+</body>
+</html>

--- a/renderer/js/hud.js
+++ b/renderer/js/hud.js
@@ -1,0 +1,115 @@
+// Mini-HUD renderer — standalone plain script; intentionally does NOT load
+// the app's component stack. The tiny format helpers are duplicated locally
+// (wrapped in an IIFE) so nothing leaks into or depends on the shared
+// renderer global scope used by index.html.
+(() => {
+  const POLL_MS = 5000;
+  const TOP_N = 3;
+  // The HUD watches dev-ish workloads; OS/system noise would otherwise
+  // dominate a raw CPU ranking.
+  const EXCLUDED_GROUPS = new Set(['system']);
+
+  let lastData = null;
+
+  const listEl = document.getElementById('hud-list');
+  const emptyEl = document.getElementById('hud-empty');
+  const badgeEl = document.getElementById('hud-warnings');
+  const closeEl = document.getElementById('hud-close');
+
+  closeEl.addEventListener('click', () => window.close());
+
+  // ── Local formatters (hud.js is standalone — no app utils loaded) ──
+  function fmtBytes(kb) {
+    if (kb < 1024) return `${kb} KB`;
+    const mb = kb / 1024;
+    if (mb < 1024) return `${mb.toFixed(1)} MB`;
+    return `${(mb / 1024).toFixed(2)} GB`;
+  }
+
+  function fmtCpu(cpu) {
+    return `${cpu.toFixed(1)}%`;
+  }
+
+  function topProcesses(data) {
+    const all = [];
+    for (const [key, group] of Object.entries(data.groups || {})) {
+      if (EXCLUDED_GROUPS.has(key)) continue;
+      for (const proc of group.processes || []) {
+        all.push(proc);
+      }
+    }
+    all.sort((a, b) => b.cpu - a.cpu);
+    return all.slice(0, TOP_N);
+  }
+
+  function render(data) {
+    const warningCount = (data.warnings || []).length;
+    badgeEl.textContent = String(warningCount);
+    badgeEl.classList.toggle('has-warnings', warningCount > 0);
+
+    const top = topProcesses(data);
+
+    listEl.textContent = '';
+    for (const proc of top) {
+      const li = document.createElement('li');
+      li.className = 'hud-row';
+
+      const name = document.createElement('span');
+      name.className = 'hud-name';
+      name.textContent = proc.name;
+      name.title = `${proc.name} (PID ${proc.pid})`;
+
+      const cpu = document.createElement('span');
+      cpu.className = 'hud-cpu';
+      cpu.textContent = fmtCpu(proc.cpu);
+
+      const mem = document.createElement('span');
+      mem.className = 'hud-mem';
+      mem.textContent = fmtBytes(proc.memKB);
+
+      li.append(name, cpu, mem);
+      listEl.appendChild(li);
+    }
+
+    emptyEl.classList.toggle('hidden', top.length > 0);
+  }
+
+  async function applyThemeFromConfig() {
+    try {
+      const cfg = await window.api.getConfig();
+      document.documentElement.setAttribute('data-theme', (cfg && cfg.theme) || 'dark');
+    } catch {
+      // Theme is cosmetic — ignore failures and keep the dark default.
+    }
+  }
+
+  async function poll() {
+    // A hidden HUD (toggle uses hide(), which keeps this renderer alive)
+    // should not keep polling in the background.
+    if (document.hidden) return;
+    try {
+      // getLastSnapshot() is a read-only view of the main poll loop's latest
+      // data (null until the first poll completes) — the HUD never triggers
+      // collection itself, so it can't race the main window's polling or
+      // swallow new-warning notifications.
+      const data = await window.api.getLastSnapshot();
+      if (data) {
+        lastData = data;
+      }
+      if (lastData) {
+        render(lastData);
+      }
+    } catch {
+      // Keep showing the last good snapshot; try again next tick.
+    }
+  }
+
+  // Refresh immediately when the window is shown again after being hidden.
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) poll();
+  });
+
+  applyThemeFromConfig();
+  poll();
+  setInterval(poll, POLL_MS);
+})();

--- a/renderer/styles/hud.css
+++ b/renderer/styles/hud.css
@@ -1,0 +1,133 @@
+/* Mini-HUD — compact always-on-top window. Uses the CSS variables from
+   main.css; solid background (no Mica in this window). */
+
+body.hud-body {
+  background: var(--bg-primary);
+  overflow: hidden;
+  user-select: none;
+}
+
+#hud {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.hud-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  -webkit-app-region: drag;
+  flex-shrink: 0;
+}
+
+.hud-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hud-badge {
+  -webkit-app-region: no-drag;
+  min-width: 20px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.hud-badge.has-warnings {
+  background: var(--accent-red);
+  color: #fff;
+}
+
+.hud-close {
+  -webkit-app-region: no-drag;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-speed), color var(--transition-speed);
+}
+
+.hud-close:hover {
+  background: var(--accent-red);
+  color: #fff;
+}
+
+.hud-close svg {
+  width: 12px;
+  height: 12px;
+}
+
+.hud-list {
+  list-style: none;
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 8px;
+}
+
+.hud-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+}
+
+.hud-row:hover {
+  background: var(--bg-hover);
+}
+
+.hud-name {
+  flex: 1;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hud-cpu {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-amber);
+  flex-shrink: 0;
+}
+
+.hud-mem {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+  min-width: 62px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.hud-empty {
+  padding: 14px 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- New compact 320x220 frameless, always-on-top, non-focusable Mini-HUD window (top-right of the primary display work area) showing the active warning count and the top-3 CPU processes across dev-ish groups (system group excluded so OS noise does not dominate).
- Toggled via the global shortcut **Ctrl+Alt+L** (registration failure is logged, never crashes -- relevant when another instance owns the accelerator) and a new **Toggle Mini-HUD** tray menu item.
- New read-only `get-last-snapshot` IPC (added at the designated anchors in `ipc-handlers.js` / `preload.js`): the HUD reads the main poll loop's latest snapshot instead of triggering collection, so it cannot race the dashboard's polling, double the collection rate, corrupt threshold sustain counters, or swallow new-warning notifications.
- HUD renderer (`renderer/js/hud.js`) is standalone (no app component stack), polls every 5 s, skips polling while hidden, refreshes immediately on show, keeps the last non-null snapshot, and applies the saved theme.
- Close button and toggle are consistent: the HUD's `close` event is intercepted and hides the window (mirroring the tray minimize-to-tray pattern); quit still destroys it.
- Fixed a latent multi-window regression: `activate` and notification-click handlers now recreate the main window keyed on the `mainWindow` ref -- the old `getAllWindows().length === 0` check would never reopen the dashboard while the HUD window exists.

## Verification
- `npm test`: 30/30 pass. `npm run lint`: clean.
- Smoke boot: app ran 15 s with no uncaught exceptions; shortcut-collision path exercised (another instance owned Ctrl+Alt+L) and logged a warning as designed.
- Note: `focusable: false` click handling (HUD close button) was not interactively verified in the smoke run (boot-only); if clicks misbehave on some setup, dropping the `focusable` flag in `main/hud-window.js` is the one-line revert.
