### PR TITLE
Snapshot diff: compare a saved JSON export against now

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -121,6 +121,16 @@ const componentGlobals = {
   onCmdPaletteKeyDown: 'writable',
   openCommandPalette: 'writable',
   closeCommandPalette: 'writable',
+  // renderer/js/components/diff-view.js
+  diffKeydownHandler: 'writable',
+  closeDiffView: 'writable',
+  importAndShowDiff: 'writable',
+  formatSigned: 'writable',
+  diffDeltaClass: 'writable',
+  renderDiffProcRow: 'writable',
+  renderDiffChangedRow: 'writable',
+  renderDiffSection: 'writable',
+  showDiffView: 'writable',
 };
 
 const appGlobals = {

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -183,6 +183,39 @@ function registerIpcHandlers() {
     }
     return { success: true, logs: getLogs(makeBufferKey(profileId, serviceId)) };
   });
+
+  // ── Snapshot diff — compare a saved JSON export against now ──
+  const { diff: diffSnapshots } = require('./services/snapshot-differ');
+
+  ipcMain.handle('import-snapshot-diff', async () => {
+    const win = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
+    const res = await dialog.showOpenDialog(win, {
+      title: 'Compare snapshot',
+      defaultPath: app.getPath('downloads'),
+      filters: [{ name: 'JSON', extensions: ['json'] }],
+      properties: ['openFile'],
+    });
+    if (res.canceled || !res.filePaths || !res.filePaths[0]) {
+      return { success: false, canceled: true };
+    }
+
+    let oldSnapshot;
+    try {
+      oldSnapshot = JSON.parse(fs.readFileSync(res.filePaths[0], 'utf8'));
+    } catch (err) {
+      return { success: false, error: `Could not read snapshot: ${err.message}` };
+    }
+
+    // collectAll() returns null when a poll is already in flight;
+    // fall back to the latest successful snapshot instead of failing.
+    const current = (await collectAll()) || getLastSnapshot();
+    if (!current) return { success: false, error: 'No current data available' };
+
+    const result = diffSnapshots(oldSnapshot, current);
+    if (!result) return { success: false, error: 'Not a valid snapshot file' };
+
+    return { success: true, diff: result, oldTimestamp: oldSnapshot.timestamp || null };
+  });
 }
 
 module.exports = { registerIpcHandlers };

--- a/main/preload.js
+++ b/main/preload.js
@@ -35,4 +35,6 @@ contextBridge.exposeInMainWorld('api', {
   dockerLogs: (id, tail) => ipcRenderer.invoke('docker-logs', id, tail),
   // ── Profile logs
   getServiceLogs: (profileId, serviceId) => ipcRenderer.invoke('get-service-logs', { profileId, serviceId }),
+  // ── Snapshot diff
+  importSnapshotDiff: () => ipcRenderer.invoke('import-snapshot-diff'),
 });

--- a/main/services/snapshot-differ.js
+++ b/main/services/snapshot-differ.js
@@ -1,0 +1,88 @@
+/**
+ * Snapshot differ — compares a previously exported snapshot against a
+ * current one and reports which processes started, died, or changed.
+ *
+ * Pure CommonJS module with no Electron dependencies so it can run in
+ * plain Node (unit tests, CI without an Electron binary).
+ */
+
+const CPU_DELTA_MIN = 1; // percentage points
+const MEM_DELTA_MIN_KB = 10240; // 10 MB
+
+/**
+ * Flatten a snapshot's `groups` object into a Map keyed by pid.
+ * Malformed groups / process entries are skipped silently.
+ */
+function flattenSnapshot(snapshot) {
+  const map = new Map();
+  const groups = snapshot.groups;
+  if (!groups || typeof groups !== 'object' || Array.isArray(groups)) return map;
+
+  for (const [key, group] of Object.entries(groups)) {
+    if (!group || !Array.isArray(group.processes)) continue;
+    for (const proc of group.processes) {
+      if (!proc || typeof proc !== 'object') continue;
+      const pid = Number(proc.pid);
+      if (!Number.isFinite(pid)) continue;
+      map.set(pid, {
+        pid,
+        name: typeof proc.name === 'string' ? proc.name : '',
+        group: typeof proc.group === 'string' ? proc.group : key,
+        cpu: Number.isFinite(proc.cpu) ? proc.cpu : 0,
+        memKB: Number.isFinite(proc.memKB) ? proc.memKB : 0,
+      });
+    }
+  }
+  return map;
+}
+
+/**
+ * Diff two snapshots.
+ *
+ * @param {object} oldSnapshot   Parsed JSON of a previously exported snapshot.
+ * @param {object} currentSnapshot  The current snapshot.
+ * @returns {{started: object[], died: object[], changed: object[]}|null}
+ *   null when either snapshot is not a usable object at all.
+ *
+ * Survivors are matched by pid AND name — a pid that reappears with a
+ * different name is treated as one process dying and another starting
+ * (guards against OS pid reuse).
+ */
+function diff(oldSnapshot, currentSnapshot) {
+  if (!oldSnapshot || typeof oldSnapshot !== 'object' || Array.isArray(oldSnapshot)) return null;
+  if (!currentSnapshot || typeof currentSnapshot !== 'object' || Array.isArray(currentSnapshot)) return null;
+
+  const oldMap = flattenSnapshot(oldSnapshot);
+  const curMap = flattenSnapshot(currentSnapshot);
+
+  const started = [];
+  const died = [];
+  const changed = [];
+
+  for (const [pid, cur] of curMap) {
+    const prev = oldMap.get(pid);
+    if (!prev || prev.name !== cur.name) {
+      // New pid, or same pid reused by a different process.
+      started.push(cur);
+      continue;
+    }
+
+    // Survivor — report only meaningful resource deltas.
+    const cpuDelta = cur.cpu - prev.cpu;
+    const memDeltaKB = cur.memKB - prev.memKB;
+    if (Math.abs(cpuDelta) >= CPU_DELTA_MIN || Math.abs(memDeltaKB) >= MEM_DELTA_MIN_KB) {
+      changed.push({ pid, name: cur.name, cpuDelta, memDeltaKB });
+    }
+  }
+
+  for (const [pid, prev] of oldMap) {
+    const cur = curMap.get(pid);
+    if (!cur || cur.name !== prev.name) {
+      died.push(prev);
+    }
+  }
+
+  return { started, died, changed };
+}
+
+module.exports = { diff };

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -16,6 +16,7 @@
         <input type="text" id="filter-input" placeholder="Filter processes... (press /)" autocomplete="off">
         <button id="cluster-btn" class="settings-btn" title="Group identical processes">&#9783;</button>
         <button id="export-btn" class="settings-btn" title="Export snapshot (Ctrl+E)">&#8595;</button>
+        <button id="import-btn" class="settings-btn" title="Compare snapshot… (Ctrl+Shift+E)">&#916;</button>
         <button id="settings-btn" class="settings-btn" title="Settings (Ctrl+,)">&#9881;</button>
         <div class="win-controls">
           <button id="win-min" class="win-btn" title="Minimize" aria-label="Minimize">
@@ -69,6 +70,7 @@
   <script src="js/components/settings.js"></script>
   <script src="js/components/profile-panel.js"></script>
   <script src="js/components/command-palette.js"></script>
+  <script src="js/components/diff-view.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/renderer/js/app.js
+++ b/renderer/js/app.js
@@ -319,6 +319,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   // registered (e.g. app launched minimized, or hidden during the config
   // await above) would otherwise be missed; startPolling() below picks it up.
   isHidden = document.visibilityState === 'hidden';
+  // Snapshot diff — compare a saved export against now
+  const importBtn = document.getElementById('import-btn');
+  if (importBtn) {
+    importBtn.addEventListener('click', importAndShowDiff);
+  }
 
   // Start polling
   startPolling();
@@ -370,5 +375,12 @@ function handleGlobalKeys(e) {
   if ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.key === 'K')) {
     e.preventDefault();
     openCommandPalette();
+  }
+
+  // Ctrl/Cmd+Shift+E — compare a saved snapshot against now
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'E' || e.key === 'e')) {
+    e.preventDefault();
+    importAndShowDiff();
+    return;
   }
 }

--- a/renderer/js/components/diff-view.js
+++ b/renderer/js/components/diff-view.js
@@ -1,0 +1,144 @@
+/* Snapshot diff view – modal comparing a saved snapshot export against now */
+
+let diffKeydownHandler = null;
+
+function closeDiffView() {
+  const modal = document.getElementById('diff-modal');
+  if (modal) modal.classList.add('hidden');
+  if (diffKeydownHandler) {
+    document.removeEventListener('keydown', diffKeydownHandler);
+    diffKeydownHandler = null;
+  }
+}
+
+/**
+ * Invoke the import dialog in the main process and show the result.
+ * Called from the header button and the Ctrl/Cmd+Shift+E shortcut.
+ */
+function importAndShowDiff() {
+  window.api.importSnapshotDiff().then((result) => {
+    if (!result || result.canceled) return;
+    if (!result.success) {
+      showToast(result.error || 'Snapshot comparison failed', { type: 'error', duration: 5000 });
+      return;
+    }
+    showDiffView(result);
+  }).catch((err) => {
+    showToast(`Snapshot comparison failed: ${err.message || err}`, { type: 'error', duration: 5000 });
+  });
+}
+
+function formatSigned(delta, fmt) {
+  return `${delta >= 0 ? '+' : '−'}${fmt(Math.abs(delta))}`;
+}
+
+function diffDeltaClass(delta) {
+  if (delta === 0) return '';
+  return delta > 0 ? 'diff-delta-up' : 'diff-delta-down';
+}
+
+function renderDiffProcRow(p) {
+  return h('div', { className: 'diff-row' }, [
+    h('span', { className: 'diff-row-name' }, p.name || '(unknown)'),
+    h('span', { className: 'diff-row-pid' }, `PID ${p.pid}`),
+    h('span', { className: 'diff-row-group' }, p.group || ''),
+    h('span', { className: 'diff-row-stat' }, formatCpu(p.cpu || 0)),
+    h('span', { className: 'diff-row-stat' }, formatBytes(p.memKB || 0)),
+  ]);
+}
+
+function renderDiffChangedRow(p) {
+  return h('div', { className: 'diff-row' }, [
+    h('span', { className: 'diff-row-name' }, p.name || '(unknown)'),
+    h('span', { className: 'diff-row-pid' }, `PID ${p.pid}`),
+    h('span', { className: 'diff-row-group' }, ''),
+    h('span', {
+      className: `diff-row-stat ${diffDeltaClass(p.cpuDelta)}`,
+    }, formatSigned(p.cpuDelta, formatCpu)),
+    h('span', {
+      className: `diff-row-stat ${diffDeltaClass(p.memDeltaKB)}`,
+    }, formatSigned(p.memDeltaKB, formatBytes)),
+  ]);
+}
+
+function renderDiffSection(title, kind, items, renderRow) {
+  const section = h('div', { className: `diff-section diff-section-${kind}` });
+  section.appendChild(h('div', { className: 'diff-section-title' }, `${title} (${items.length})`));
+  const list = h('div', { className: 'diff-list' });
+  for (const item of items) {
+    list.appendChild(renderRow(item));
+  }
+  section.appendChild(list);
+  return section;
+}
+
+/**
+ * Show the diff modal.
+ * @param {{diff: {started: [], died: [], changed: []}, oldTimestamp: number|null}} result
+ */
+function showDiffView(result) {
+  const d = (result && result.diff) || {};
+  const started = Array.isArray(d.started) ? d.started : [];
+  const died = Array.isArray(d.died) ? d.died : [];
+  const changed = Array.isArray(d.changed) ? d.changed : [];
+
+  let modal = document.getElementById('diff-modal');
+  if (!modal) {
+    modal = h('div', { id: 'diff-modal', className: 'modal hidden' });
+    // Close on backdrop click — attached once, on creation.
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) closeDiffView();
+    });
+    document.body.appendChild(modal);
+  }
+
+  modal.innerHTML = '';
+  modal.classList.remove('hidden');
+
+  const content = h('div', { className: 'modal-content diff-content' });
+
+  // Header — show when the compared snapshot was taken
+  const when = result && result.oldTimestamp
+    ? new Date(result.oldTimestamp).toLocaleString()
+    : 'unknown time';
+  const header = h('div', { className: 'diff-header' }, [
+    h('div', {}, [
+      h('h2', {}, 'Snapshot comparison'),
+      h('span', { className: 'diff-timestamp' }, `Compared against snapshot from ${when}`),
+    ]),
+    h('button', {
+      className: 'settings-close',
+      title: 'Close',
+      onClick: closeDiffView,
+    }, '×'),
+  ]);
+  content.appendChild(header);
+
+  const body = h('div', { className: 'diff-body' });
+
+  if (started.length === 0 && died.length === 0 && changed.length === 0) {
+    body.appendChild(h('div', { className: 'diff-empty' },
+      'No changes since snapshot — everything is exactly as it was.'));
+  } else {
+    if (started.length > 0) {
+      body.appendChild(renderDiffSection('Started', 'started', started, renderDiffProcRow));
+    }
+    if (died.length > 0) {
+      body.appendChild(renderDiffSection('Died', 'died', died, renderDiffProcRow));
+    }
+    if (changed.length > 0) {
+      body.appendChild(renderDiffSection('Changed', 'changed', changed, renderDiffChangedRow));
+    }
+  }
+
+  content.appendChild(body);
+  modal.appendChild(content);
+
+  // Close on Escape key — closeDiffView removes the handler again,
+  // whichever way the modal is dismissed.
+  if (diffKeydownHandler) document.removeEventListener('keydown', diffKeydownHandler);
+  diffKeydownHandler = (e) => {
+    if (e.key === 'Escape') closeDiffView();
+  };
+  document.addEventListener('keydown', diffKeydownHandler);
+}

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -1732,4 +1732,119 @@
   max-width: 90px;
   display: inline-block;
   vertical-align: bottom;
+/* ── Snapshot diff ─────────── */
+.diff-content {
+  width: 560px;
+  max-width: 90vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.diff-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.diff-header h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.diff-timestamp {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.diff-body {
+  overflow-y: auto;
+  padding: 12px 20px 16px;
+}
+
+.diff-empty {
+  padding: 24px 8px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.diff-section {
+  margin-bottom: 16px;
+  border-left: 3px solid var(--border-color);
+  padding-left: 12px;
+}
+
+.diff-section:last-child {
+  margin-bottom: 0;
+}
+
+.diff-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+
+.diff-section-started {
+  border-left-color: var(--accent-green);
+}
+
+.diff-section-started .diff-section-title {
+  color: var(--accent-green);
+}
+
+.diff-section-died {
+  border-left-color: var(--accent-red);
+}
+
+.diff-section-died .diff-section-title {
+  color: var(--accent-red);
+}
+
+.diff-section-changed {
+  border-left-color: var(--accent-amber);
+}
+
+.diff-section-changed .diff-section-title {
+  color: var(--accent-amber);
+}
+
+.diff-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto 72px 88px;
+  gap: 10px;
+  align-items: baseline;
+  padding: 3px 0;
+  font-size: 13px;
+}
+
+.diff-row-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.diff-row-pid,
+.diff-row-group {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.diff-row-stat {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.diff-delta-up {
+  color: var(--accent-red);
+}
+
+.diff-delta-down {
+  color: var(--accent-green);
 }

--- a/test/snapshot-differ.test.js
+++ b/test/snapshot-differ.test.js
@@ -1,0 +1,185 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { diff } = require('../main/services/snapshot-differ');
+
+/** Build a snapshot with a single "dev" group holding the given processes. */
+function snap(processes, extra = {}) {
+  return {
+    groups: {
+      dev: { key: 'dev', icon: '', label: 'Dev', order: 0, processes, totalCpu: 0, totalMemKB: 0 },
+    },
+    containers: [],
+    warnings: [],
+    timestamp: Date.now(),
+    totalProcesses: processes.length,
+    ...extra,
+  };
+}
+
+function proc(pid, name, cpu = 0, memKB = 0, group = 'dev') {
+  return { pid, name, cpu, memKB, group, started: 0, ports: [], portDetails: [], hasWarning: false };
+}
+
+test('detects started processes (present only in current)', () => {
+  const result = diff(
+    snap([proc(1, 'node.exe', 2, 1000)]),
+    snap([proc(1, 'node.exe', 2, 1000), proc(2, 'vite.exe', 5, 2048)]),
+  );
+
+  assert.deepStrictEqual(result.died, []);
+  assert.deepStrictEqual(result.changed, []);
+  assert.strictEqual(result.started.length, 1);
+  assert.deepStrictEqual(result.started[0], {
+    pid: 2, name: 'vite.exe', group: 'dev', cpu: 5, memKB: 2048,
+  });
+});
+
+test('detects died processes (present only in old)', () => {
+  const result = diff(
+    snap([proc(1, 'node.exe', 2, 1000), proc(3, 'postgres.exe', 1, 4096)]),
+    snap([proc(1, 'node.exe', 2, 1000)]),
+  );
+
+  assert.deepStrictEqual(result.started, []);
+  assert.deepStrictEqual(result.changed, []);
+  assert.strictEqual(result.died.length, 1);
+  assert.deepStrictEqual(result.died[0], {
+    pid: 3, name: 'postgres.exe', group: 'dev', cpu: 1, memKB: 4096,
+  });
+});
+
+test('detects changed survivors with meaningful deltas', () => {
+  const result = diff(
+    snap([proc(1, 'node.exe', 2, 100000)]),
+    snap([proc(1, 'node.exe', 50, 300000)]),
+  );
+
+  assert.deepStrictEqual(result.started, []);
+  assert.deepStrictEqual(result.died, []);
+  assert.deepStrictEqual(result.changed, [
+    { pid: 1, name: 'node.exe', cpuDelta: 48, memDeltaKB: 200000 },
+  ]);
+});
+
+test('reports negative deltas too', () => {
+  const result = diff(
+    snap([proc(1, 'node.exe', 50, 300000)]),
+    snap([proc(1, 'node.exe', 2, 100000)]),
+  );
+
+  assert.deepStrictEqual(result.changed, [
+    { pid: 1, name: 'node.exe', cpuDelta: -48, memDeltaKB: -200000 },
+  ]);
+});
+
+test('ignores survivors below both thresholds', () => {
+  // |cpuDelta| < 1 and |memDeltaKB| < 10240 → not "changed"
+  const result = diff(
+    snap([proc(1, 'node.exe', 5, 100000)]),
+    snap([proc(1, 'node.exe', 5.5, 105000)]),
+  );
+
+  assert.deepStrictEqual(result.changed, []);
+  assert.deepStrictEqual(result.started, []);
+  assert.deepStrictEqual(result.died, []);
+});
+
+test('either threshold alone is enough to count as changed', () => {
+  // Only CPU crosses
+  const cpuOnly = diff(
+    snap([proc(1, 'node.exe', 5, 1000)]),
+    snap([proc(1, 'node.exe', 6, 1000)]),
+  );
+  assert.strictEqual(cpuOnly.changed.length, 1);
+
+  // Only memory crosses (10240 KB = 10 MB)
+  const memOnly = diff(
+    snap([proc(1, 'node.exe', 5, 1000)]),
+    snap([proc(1, 'node.exe', 5, 1000 + 10240)]),
+  );
+  assert.strictEqual(memOnly.changed.length, 1);
+});
+
+test('pid reuse: same pid with a different name is died + started, not changed', () => {
+  const result = diff(
+    snap([proc(42, 'node.exe', 10, 50000)]),
+    snap([proc(42, 'python.exe', 90, 900000)]),
+  );
+
+  assert.deepStrictEqual(result.changed, []);
+  assert.strictEqual(result.died.length, 1);
+  assert.strictEqual(result.died[0].name, 'node.exe');
+  assert.strictEqual(result.started.length, 1);
+  assert.strictEqual(result.started[0].name, 'python.exe');
+  assert.strictEqual(result.started[0].pid, 42);
+});
+
+test('flattens processes across multiple groups', () => {
+  const old = {
+    groups: {
+      dev: { processes: [proc(1, 'node.exe')] },
+      databases: { processes: [{ pid: 2, name: 'postgres.exe', cpu: 1, memKB: 100 }] },
+    },
+  };
+  const cur = { groups: { dev: { processes: [proc(1, 'node.exe')] } } };
+
+  const result = diff(old, cur);
+  assert.strictEqual(result.died.length, 1);
+  assert.strictEqual(result.died[0].pid, 2);
+  // Group falls back to the containing group key when proc.group is missing
+  assert.strictEqual(result.died[0].group, 'databases');
+});
+
+test('returns null for totally invalid snapshots', () => {
+  const valid = snap([]);
+  assert.strictEqual(diff(null, valid), null);
+  assert.strictEqual(diff(valid, null), null);
+  assert.strictEqual(diff(undefined, valid), null);
+  assert.strictEqual(diff('not a snapshot', valid), null);
+  assert.strictEqual(diff(42, valid), null);
+  assert.strictEqual(diff([], valid), null);
+  assert.strictEqual(diff(valid, 'nope'), null);
+});
+
+test('treats missing or malformed groups as empty', () => {
+  const cur = snap([proc(1, 'node.exe', 5, 2048)]);
+
+  // No groups key at all → everything in current counts as started
+  const noGroups = diff({ timestamp: 1 }, cur);
+  assert.strictEqual(noGroups.started.length, 1);
+  assert.deepStrictEqual(noGroups.died, []);
+
+  // groups is the wrong type → same
+  assert.strictEqual(diff({ groups: 'bad' }, cur).started.length, 1);
+  assert.strictEqual(diff({ groups: [1, 2] }, cur).started.length, 1);
+
+  // Malformed group entries and process entries are skipped
+  const messy = {
+    groups: {
+      dev: { processes: [null, 'junk', { name: 'no-pid.exe' }, { pid: 'NaN-pid' }, proc(1, 'node.exe', 5, 2048)] },
+      broken: null,
+      alsoBroken: { processes: 'not-an-array' },
+    },
+  };
+  const result = diff(messy, cur);
+  assert.deepStrictEqual(result.started, []);
+  assert.deepStrictEqual(result.died, []);
+  assert.deepStrictEqual(result.changed, []);
+});
+
+test('missing cpu/mem fields default to 0 rather than producing NaN', () => {
+  const result = diff(
+    { groups: { dev: { processes: [{ pid: 1, name: 'node.exe' }] } } },
+    snap([proc(1, 'node.exe', 3, 20480)]),
+  );
+
+  assert.deepStrictEqual(result.changed, [
+    { pid: 1, name: 'node.exe', cpuDelta: 3, memDeltaKB: 20480 },
+  ]);
+});
+
+test('empty diff for identical snapshots', () => {
+  const s = snap([proc(1, 'node.exe', 5, 1000), proc(2, 'vite.exe', 1, 500)]);
+  const result = diff(s, snap([proc(1, 'node.exe', 5, 1000), proc(2, 'vite.exe', 1, 500)]));
+  assert.deepStrictEqual(result, { started: [], died: [], changed: [] });
+});


### PR DESCRIPTION
## Summary
- New pure-Node service `main/services/snapshot-differ.js` (Electron-free, CI-safe): flattens both snapshots' `groups` into pid-keyed maps and returns `{started, died, changed}`. Survivors are matched by pid AND name to guard against OS pid reuse; changed deltas below 1% CPU / 10 MB RAM are filtered as noise. Malformed input is handled defensively (missing groups → empty; totally invalid snapshots → null).
- New `import-snapshot-diff` IPC handler (mirrors the export-snapshot style): JSON open dialog defaulting to Downloads, parse in try/catch, diff against `(await collectAll()) || getLastSnapshot()`, returns `{success, diff, oldTimestamp}` or canceled/error results.
- New renderer component `renderer/js/components/diff-view.js`: runtime-built modal (settings.js pattern) with Started (green) / Died (red) / Changed (amber) sections, signed CPU/RAM deltas via formatCpu/formatBytes, the old snapshot's timestamp in the header, and a friendly "no changes" empty state. Esc/backdrop close without stacking listeners across opens.
- Wiring: header `#import-btn` (before the settings gear) and a Ctrl/Cmd+Shift+E shortcut; canceled/error results surface via toasts.
- Merge-safety conventions followed: anchor-only additions in ipc-handlers/preload, appended-only app.js wiring and components.css block, only the two granted index.html edits.

## Testing
- `npm test`: 42/42 pass, including new `test/snapshot-differ.test.js` (started/died/changed detection, pid-reuse guard, threshold filtering, malformed-input safety).
- `npm run lint`: clean.
- Smoke boot: `npm start` ran ~16 s with no uncaught exceptions or renderer errors (only benign GPU cache noise from a concurrent Electron instance); process tree killed by PID afterwards.
