### PR TITLE
Add HTTP health checks on listening ports

### DIFF
--- a/main/collectors/health-collector.js
+++ b/main/collectors/health-collector.js
@@ -1,0 +1,93 @@
+const http = require('node:http');
+
+const PROBE_TIMEOUT_MS = 800;
+const PROBE_INTERVAL_MS = 5000; // re-probe at most this often (~every 2-5 polls)
+
+function defaultHttpGet(url, options, callback) {
+  return http.get(url, options, callback);
+}
+
+/**
+ * Probe a single port with an HTTP GET. Any HTTP response (even 500)
+ * counts as up; connection refused/timeout/reset counts as down.
+ * Never rejects.
+ *
+ * Limitation: probes plain HTTP on 127.0.0.1 only — HTTPS-only or
+ * IPv6-only servers will report as down.
+ */
+function probePort(port, httpGet) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const req = httpGet(
+      `http://127.0.0.1:${port}/`,
+      { timeout: PROBE_TIMEOUT_MS, agent: false },
+      (res) => {
+        res.resume(); // drain so the socket is released
+        resolve({ up: true, latencyMs: Date.now() - started });
+      }
+    );
+    // destroy(err) surfaces as an 'error' event, which resolves as down
+    req.on('timeout', () => req.destroy(new Error('probe timeout')));
+    req.on('error', () => resolve({ up: false, latencyMs: null }));
+  });
+}
+
+/**
+ * Probe a list of ports concurrently (deduped).
+ * Returns Map<port, { up: boolean, latencyMs: number|null }>.
+ * `httpGet` is injectable for tests.
+ */
+async function probe(ports, { httpGet = defaultHttpGet } = {}) {
+  const unique = [...new Set(ports || [])];
+  const results = await Promise.all(unique.map((p) => probePort(p, httpGet)));
+  return new Map(unique.map((port, i) => [port, results[i]]));
+}
+
+let lastProbeAt = -Infinity;
+let probing = false;
+let cachedHealth = new Map();
+
+/**
+ * Throttling wrapper around probe(). Returns the cached Map immediately
+ * (never blocks the poll) and, at most every PROBE_INTERVAL_MS, kicks off
+ * a background probe that refreshes the cache for the next poll. Cache
+ * entries for ports no longer listening are dropped; ports not yet probed
+ * simply have no entry (unknown).
+ *
+ * `opts.httpGet` and `opts.now` are injectable for tests.
+ */
+function collect(ports, opts = {}) {
+  const now = opts.now || Date.now;
+
+  // Drop stale entries for ports that are no longer listening
+  const portSet = new Set(ports || []);
+  for (const port of [...cachedHealth.keys()]) {
+    if (!portSet.has(port)) cachedHealth.delete(port);
+  }
+
+  const t = now();
+  if (!probing && t - lastProbeAt >= PROBE_INTERVAL_MS) {
+    probing = true;
+    lastProbeAt = t;
+    probe(ports, opts).then(
+      (map) => {
+        cachedHealth = map;
+        probing = false;
+      },
+      () => {
+        probing = false;
+      }
+    );
+  }
+
+  return cachedHealth;
+}
+
+// Reset throttle state and cached results (for tests)
+function resetCache() {
+  lastProbeAt = -Infinity;
+  probing = false;
+  cachedHealth = new Map();
+}
+
+module.exports = { probe, collect, resetCache };

--- a/main/poll-manager.js
+++ b/main/poll-manager.js
@@ -6,6 +6,7 @@ const { classify, GROUP_META } = require('./services/classifier');
 const { detect, detectThresholds, detectDuplicates } = require('./services/anomaly-detector');
 const config = require('./services/config');
 const cpuAccumulator = require('./services/cpu-accumulator');
+const healthCollector = require('./collectors/health-collector');
 
 let busy = false;
 let lastSnapshot = null;
@@ -82,6 +83,29 @@ async function collectAll() {
 
     // Accumulate per-process CPU cost (attaches proc.cpuTimeSec)
     cpuAccumulator.update(merged, Date.now());
+    // HTTP health checks: attach per-port up/down + latency to web-ish
+    // processes. Only dev/apps groups are probed — databases and system
+    // services don't speak HTTP and would show as permanently down.
+    // collect() is non-blocking: it returns the cached results and
+    // refreshes them in a throttled background probe, so the poll's
+    // snapshot is never delayed. Health may lag one poll.
+    if (config.get('portHealthChecks')) {
+      const HEALTH_GROUPS = new Set(['dev', 'apps']);
+      const webProcs = merged.filter((p) => HEALTH_GROUPS.has(p.group) && p.ports.length > 0);
+      const health = healthCollector.collect(webProcs.flatMap((p) => p.ports));
+      for (const proc of webProcs) {
+        const portHealth = {};
+        let hasAny = false;
+        for (const port of proc.ports) {
+          const status = health.get(port);
+          if (status) {
+            portHealth[port] = status;
+            hasAny = true;
+          }
+        }
+        if (hasAny) proc.portHealth = portHealth;
+      }
+    }
 
     // Detect anomalies (port conflicts + resource thresholds)
     const warnings = detect(merged);

--- a/main/services/config.js
+++ b/main/services/config.js
@@ -20,6 +20,7 @@ const DEFAULTS = {
   clusterProcesses: true,  // collapse same-named processes into clusters in the UI
   // [anchor: feature keys] — new feature config keys go below this line
   hiddenPollInterval: 15,  // seconds (5–120) — poll cadence while the window is hidden
+  portHealthChecks: true,  // probe listening ports over HTTP and show up/down status
 };
 
 const VALID_THEMES = ['dark', 'light'];
@@ -114,6 +115,7 @@ function validate(cfg) {
 
   // hiddenPollInterval: clamp to 5–120
   result.hiddenPollInterval = Math.max(5, Math.min(120, Number(result.hiddenPollInterval) || DEFAULTS.hiddenPollInterval));
+  result.portHealthChecks = !!result.portHealthChecks;
 
   return result;
 }

--- a/renderer/js/components/process-table.js
+++ b/renderer/js/components/process-table.js
@@ -153,7 +153,7 @@ function buildProcessThead() {
 }
 
 // ── Port cell ──────────────────────────────────────────────────
-function renderPortCell(ports) {
+function renderPortCell(ports, portHealth) {
   if (!ports || ports.length === 0) return h('span', {}, '—');
 
   const container = h('span', { className: 'port-cell' });
@@ -164,6 +164,14 @@ function renderPortCell(ports) {
       title: `Open http://localhost:${port}`,
       href: '#',
     }, String(port));
+    const status = portHealth && portHealth[port];
+    if (status) {
+      const dotClass = `port-health ${status.up ? 'port-health-up' : 'port-health-down'}`;
+      const dotTitle = status.up
+        ? (status.latencyMs != null ? `up, ${status.latencyMs} ms` : 'up')
+        : 'down';
+      link.insertBefore(h('span', { className: dotClass, title: dotTitle }), link.firstChild);
+    }
     link.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
@@ -229,7 +237,7 @@ function populateRow(tr, proc, opts = {}) {
 
   tr.appendChild(h('td', { className: 'col-name', title: proc.name }, nameChildren));
   tr.appendChild(h('td', { className: 'col-pid' }, proc.pid.toString()));
-  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(proc.ports)]));
+  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(proc.ports, proc.portHealth)]));
   tr.appendChild(cpuCell);
   tr.appendChild(ramCell);
   tr.appendChild(h('td', { className: 'col-uptime' }, formatUptime(proc.started)));
@@ -257,6 +265,7 @@ function clusterAggregate(procs) {
   let totalMem = 0;
   let oldest = Infinity;
   const portSet = new Set();
+  const portHealth = {};
   let anyWarning = false;
 
   for (const p of procs) {
@@ -264,6 +273,7 @@ function clusterAggregate(procs) {
     totalMem += p.memKB || 0;
     if (p.started && p.started < oldest) oldest = p.started;
     if (p.ports) for (const port of p.ports) portSet.add(port);
+    if (p.portHealth) Object.assign(portHealth, p.portHealth);
     if (p.hasWarning) anyWarning = true;
   }
 
@@ -272,6 +282,7 @@ function clusterAggregate(procs) {
     totalMem,
     oldest: oldest === Infinity ? null : oldest,
     ports: Array.from(portSet).sort((a, b) => a - b),
+    portHealth,
     anyWarning,
   };
 }
@@ -316,7 +327,7 @@ function populateClusterRow(tr, cluster) {
 
   tr.appendChild(nameCell);
   tr.appendChild(h('td', { className: 'col-pid cluster-pid' }, `${procs.length} pids`));
-  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(agg.ports)]));
+  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(agg.ports, agg.portHealth)]));
   tr.appendChild(cpuCell);
   tr.appendChild(ramCell);
   tr.appendChild(h('td', { className: 'col-uptime' }, formatUptime(agg.oldest)));

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -1591,4 +1591,27 @@
 .service-log-empty {
   color: var(--text-secondary);
   font-style: italic;
+/* ── Port health ─────────── */
+.port-health {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-right: 4px;
+  vertical-align: middle;
+  background: var(--text-muted);
+  opacity: 0.35;
+}
+
+/* Matches .container-state-dot glow so status reads the same in both tables */
+.port-health.port-health-up {
+  background: var(--accent-green);
+  box-shadow: 0 0 4px rgba(158, 206, 106, 0.5);
+  opacity: 1;
+}
+
+.port-health.port-health-down {
+  background: var(--accent-red);
+  box-shadow: 0 0 4px rgba(247, 118, 142, 0.5);
+  opacity: 1;
 }

--- a/test/health-collector.test.js
+++ b/test/health-collector.test.js
@@ -1,0 +1,166 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { probe, collect, resetCache } = require('../main/collectors/health-collector');
+
+// Build a fake httpGet. `behavior` maps port -> 'ok' | 'http500' | 'error' | 'timeout'.
+// Records every probed port in fn.calls.
+function makeHttpGet(behavior) {
+  const fn = (url, options, callback) => {
+    const port = Number(new URL(url).port);
+    fn.calls.push(port);
+
+    const req = new EventEmitter();
+    // Mirror the real ClientRequest: destroy(err) surfaces as an 'error' event
+    req.destroy = (err) => req.emit('error', err || new Error('socket destroyed'));
+
+    const mode = behavior[port] || 'error';
+    setImmediate(() => {
+      if (mode === 'ok') {
+        callback({ statusCode: 200, resume() {} });
+      } else if (mode === 'http500') {
+        callback({ statusCode: 500, resume() {} });
+      } else if (mode === 'timeout') {
+        req.emit('timeout');
+      } else {
+        req.emit('error', new Error('connect ECONNREFUSED 127.0.0.1:' + port));
+      }
+    });
+    return req;
+  };
+  fn.calls = [];
+  return fn;
+}
+
+// Let the fake's setImmediate callbacks and follow-up microtasks run
+function tick() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+beforeEach(() => resetCache());
+
+test('probe marks a responding port as up with a latency', async () => {
+  const httpGet = makeHttpGet({ 3000: 'ok' });
+  const result = await probe([3000], { httpGet });
+
+  const status = result.get(3000);
+  assert.strictEqual(status.up, true);
+  assert.strictEqual(typeof status.latencyMs, 'number');
+  assert.ok(status.latencyMs >= 0);
+});
+
+test('probe counts any HTTP response as up, even a 500', async () => {
+  const httpGet = makeHttpGet({ 8080: 'http500' });
+  const result = await probe([8080], { httpGet });
+
+  assert.strictEqual(result.get(8080).up, true);
+});
+
+test('probe marks refused connections as down with null latency', async () => {
+  const httpGet = makeHttpGet({ 5000: 'error' });
+  const result = await probe([5000], { httpGet });
+
+  assert.deepStrictEqual(result.get(5000), { up: false, latencyMs: null });
+});
+
+test('probe marks timed-out connections as down', async () => {
+  const httpGet = makeHttpGet({ 9000: 'timeout' });
+  const result = await probe([9000], { httpGet });
+
+  assert.deepStrictEqual(result.get(9000), { up: false, latencyMs: null });
+});
+
+test('probe handles a mix of ports concurrently and dedupes', async () => {
+  const httpGet = makeHttpGet({ 3000: 'ok', 5432: 'error' });
+  const result = await probe([3000, 5432, 3000], { httpGet });
+
+  assert.strictEqual(result.size, 2);
+  assert.strictEqual(result.get(3000).up, true);
+  assert.strictEqual(result.get(5432).up, false);
+  // Deduped: 3000 probed once
+  assert.deepStrictEqual([...httpGet.calls].sort((a, b) => a - b), [3000, 5432]);
+});
+
+test('probe of an empty port list returns an empty Map', async () => {
+  const httpGet = makeHttpGet({});
+  const result = await probe([], { httpGet });
+  assert.strictEqual(result.size, 0);
+  assert.strictEqual(httpGet.calls.length, 0);
+});
+
+test('collect never blocks: first call returns empty, results land next call', async () => {
+  const httpGet = makeHttpGet({ 3000: 'ok' });
+  let t = 0;
+  const now = () => t;
+
+  const first = collect([3000], { httpGet, now });
+  assert.strictEqual(first.size, 0, 'probe runs in background, nothing cached yet');
+  assert.strictEqual(httpGet.calls.length, 1, 'probe kicked off');
+
+  await tick();
+
+  const second = collect([3000], { httpGet, now });
+  assert.strictEqual(second.get(3000).up, true);
+});
+
+test('collect throttles: cached results within the interval, re-probe after it', async () => {
+  const httpGet = makeHttpGet({ 3000: 'ok' });
+  let t = 0;
+  const now = () => t;
+
+  collect([3000], { httpGet, now });
+  await tick();
+
+  t += 1000; // still inside the probe interval
+  collect([3000], { httpGet, now });
+  t += 1000;
+  collect([3000], { httpGet, now });
+  assert.strictEqual(httpGet.calls.length, 1, 'calls within the interval use the cache');
+
+  t += 60000; // well past the interval
+  collect([3000], { httpGet, now });
+  assert.strictEqual(httpGet.calls.length, 2, 'a call after the interval re-probes');
+});
+
+test('collect drops cached entries for ports no longer listening', async () => {
+  const httpGet = makeHttpGet({ 3000: 'ok', 4000: 'ok' });
+  let t = 0;
+  const now = () => t;
+
+  collect([3000, 4000], { httpGet, now });
+  await tick();
+
+  t += 1000; // within interval: cached call, but 4000 is gone
+  const cached = collect([3000], { httpGet, now });
+  assert.strictEqual(cached.get(3000).up, true);
+  assert.strictEqual(cached.has(4000), false, 'stale port pruned from cache');
+});
+
+test('unprobed ports have no entry in the collected map (unknown)', async () => {
+  const httpGet = makeHttpGet({ 3000: 'ok' });
+  let t = 0;
+  const now = () => t;
+
+  collect([3000], { httpGet, now });
+  await tick();
+
+  t += 1000; // within interval; 5000 appeared but has not been probed yet
+  const cached = collect([3000, 5000], { httpGet, now });
+  assert.strictEqual(cached.has(5000), false);
+});
+
+test('resetCache clears the throttle and cache so the next collect re-probes', async () => {
+  const httpGet = makeHttpGet({ 3000: 'ok' });
+  let t = 0;
+  const now = () => t;
+
+  collect([3000], { httpGet, now });
+  await tick();
+  assert.strictEqual(httpGet.calls.length, 1);
+
+  resetCache();
+
+  const afterReset = collect([3000], { httpGet, now });
+  assert.strictEqual(afterReset.size, 0, 'cache cleared');
+  assert.strictEqual(httpGet.calls.length, 2, 'collect after resetCache probes again');
+});


### PR DESCRIPTION
## Summary
- New `main/collectors/health-collector.js`: probes listening ports at `http://127.0.0.1:<port>/` with an 800 ms timeout; any HTTP response (even 500) counts as up, refused/timeout/reset counts as down. `collect()` is non-blocking — it returns cached results immediately and refreshes them via a throttled (5 s) background probe, so the poll snapshot is never delayed and dev servers aren't hammered.
- `poll-manager` enricher attaches `proc.portHealth = { <port>: { up, latencyMs } }`, probing only `dev`/`apps` groups (databases and system services don't speak HTTP and would read as permanently down).
- Renderer: a small green/red status dot with an "up, N ms"/"down" tooltip inside each `.port-link`, for both individual rows and aggregated cluster rows; no dot when health is unknown. Dot styling matches the existing container state dots.
- New config key `portHealthChecks` (boolean, default on).
- Cache entries for ports no longer listening are pruned; stale cache can't show a dead port as up.

Known limitation (noted in code): probes plain HTTP on IPv4 loopback only, so HTTPS-only or IPv6-only servers show as down.

## Testing
- 11 new unit tests in `test/health-collector.test.js` with an injected `httpGet` fake: up/latency, 500-counts-as-up, refused/timeout down, dedupe, throttle cache, stale-port pruning, unknown ports, `resetCache`. Full suite: 41 pass.
- `npm run lint` clean.
- Smoke boot on Windows: app ran ~35 s with no uncaught exceptions or renderer errors.
