### PR TITLE
Add Docker container actions: stop, restart, and logs

### DIFF
--- a/main/collectors/docker-collector.js
+++ b/main/collectors/docker-collector.js
@@ -1,4 +1,4 @@
-const { execFile } = require('child_process');
+const { execFile, spawn } = require('child_process');
 const { promisify } = require('util');
 
 const execFileAsync = promisify(execFile);
@@ -117,4 +117,146 @@ function resetCache() {
   dockerAvailable = null;
 }
 
-module.exports = { collect, resetCache, parseDockerJson, parsePorts };
+// ── Container actions ──────────────────────────────────────────
+// Container ids/names as reported by `docker ps`: hex ids or names made of
+// [a-zA-Z0-9_.-]. Anything else (spaces, shell metacharacters, empty) is
+// rejected main-side — the renderer is not trusted.
+const CONTAINER_ID_RE = /^[a-zA-Z0-9_.-]+$/;
+
+function isValidContainerId(id) {
+  return typeof id === 'string' && CONTAINER_ID_RE.test(id);
+}
+
+// Generous timeout: `docker stop` waits up to 10s for the container to exit
+// before SIGKILL, and `docker restart` stops then starts.
+const ACTION_TIMEOUT_MS = 15000;
+const LOGS_TIMEOUT_MS = 10000;
+// Cap collected log output; `--tail 200` should stay far below this.
+const LOGS_MAX_BYTES = 1024 * 1024;
+
+// Map raw docker CLI/exec errors to actionable messages (same pattern as
+// services/process-killer.js); fall back to the raw message.
+function friendlyDockerError(raw) {
+  const msg = String(raw || '').trim();
+  if (/cannot connect to the docker daemon|docker daemon is not running|error during connect|docker_engine/i.test(msg)) {
+    return 'Docker daemon is not running';
+  }
+  if (/no such container/i.test(msg)) {
+    return 'Container no longer exists';
+  }
+  if (/access.denied|permission denied|operation not permitted/i.test(msg)) {
+    return 'Access denied — check Docker permissions';
+  }
+  if (/ENOENT/.test(msg)) {
+    return 'Docker CLI not found';
+  }
+  if (/ETIMEDOUT|timed? ?out/i.test(msg)) {
+    return 'Docker command timed out';
+  }
+  return msg || 'Unknown error';
+}
+
+function clampTail(tail) {
+  return Number.isInteger(tail) && tail > 0 && tail <= 10000 ? tail : 200;
+}
+
+async function runContainerCommand(subcommand, id) {
+  if (!isValidContainerId(id)) {
+    return { success: false, error: 'Invalid container id' };
+  }
+
+  try {
+    // `--` stops flag parsing so an id starting with `-` can't become a flag.
+    await execFileAsync('docker', [subcommand, '--', id], {
+      encoding: 'utf-8',
+      timeout: ACTION_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: friendlyDockerError(err.stderr || err.message || err) };
+  }
+}
+
+const stopContainer = (id) => runContainerCommand('stop', id);
+const restartContainer = (id) => runContainerCommand('restart', id);
+
+function getLogs(id, tail = 200) {
+  if (!isValidContainerId(id)) {
+    return Promise.resolve({ success: false, logs: '', error: 'Invalid container id' });
+  }
+
+  // Docker writes container logs to both stdout and stderr depending on which
+  // stream the containerised process used. execFile would hand us two separate
+  // buffers and lose chronology, so spawn and append chunks from both streams
+  // in ARRIVAL order instead.
+  return new Promise((resolve) => {
+    const child = spawn(
+      'docker',
+      ['logs', '--tail', String(clampTail(tail)), '--', id],
+      { windowsHide: true }
+    );
+
+    const chunks = [];
+    let total = 0;
+    let truncated = false;
+    let settled = false;
+    let timer = null;
+
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const append = (chunk) => {
+      if (truncated) return;
+      chunks.push(chunk);
+      total += chunk.length;
+      if (total > LOGS_MAX_BYTES) {
+        truncated = true;
+        child.kill();
+      }
+    };
+    child.stdout.on('data', append);
+    child.stderr.on('data', append);
+
+    timer = setTimeout(() => {
+      child.kill();
+      settle({ success: false, logs: '', error: 'Docker command timed out' });
+    }, LOGS_TIMEOUT_MS);
+
+    child.on('error', (err) => {
+      settle({ success: false, logs: '', error: friendlyDockerError(err.message || err) });
+    });
+
+    child.on('close', (code) => {
+      const output = Buffer.concat(chunks).toString('utf-8');
+      if (truncated) {
+        settle({ success: true, logs: `${output}\n… output truncated …` });
+      } else if (code === 0) {
+        settle({ success: true, logs: output });
+      } else {
+        settle({
+          success: false,
+          logs: '',
+          error: friendlyDockerError(output || `docker logs exited with code ${code}`),
+        });
+      }
+    });
+  });
+}
+
+module.exports = {
+  collect,
+  resetCache,
+  parseDockerJson,
+  parsePorts,
+  isValidContainerId,
+  friendlyDockerError,
+  clampTail,
+  stopContainer,
+  restartContainer,
+  getLogs,
+};

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -8,6 +8,7 @@ const { collect: collectDetails, getExecutablePath } = require('./collectors/det
 const { updateTooltip } = require('./tray-manager');
 const notifier = require('./services/notifier');
 const config = require('./services/config');
+const dockerCollector = require('./collectors/docker-collector');
 
 function registerIpcHandlers() {
   // Initialise notifier from saved config
@@ -165,6 +166,16 @@ function registerIpcHandlers() {
   });
 
   // [anchor: feature handlers] — new feature IPC handlers go below this line
+
+  // ── Docker actions ───────────────────────────────────────────
+  // The renderer only sends a container id (plus an optional tail count for
+  // logs); the id is validated inside the collector so an untrusted renderer
+  // can never smuggle arbitrary arguments to the docker CLI.
+  ipcMain.handle('docker-stop', (_event, id) => dockerCollector.stopContainer(id));
+
+  ipcMain.handle('docker-restart', (_event, id) => dockerCollector.restartContainer(id));
+
+  ipcMain.handle('docker-logs', (_event, id, tail) => dockerCollector.getLogs(id, tail));
 }
 
 module.exports = { registerIpcHandlers };

--- a/main/preload.js
+++ b/main/preload.js
@@ -29,4 +29,8 @@ contextBridge.exposeInMainWorld('api', {
   onWindowVisibility: (callback) => {
     ipcRenderer.on('window-visibility', (_e, visible) => callback(visible));
   },
+  // ── Docker actions
+  dockerStop: (id) => ipcRenderer.invoke('docker-stop', id),
+  dockerRestart: (id) => ipcRenderer.invoke('docker-restart', id),
+  dockerLogs: (id, tail) => ipcRenderer.invoke('docker-logs', id, tail),
 });

--- a/renderer/js/components/container-table.js
+++ b/renderer/js/components/container-table.js
@@ -20,6 +20,160 @@ function formatContainerPorts(ports) {
   }).join(', ');
 }
 
+// ── Docker actions state ───────────────────────────────────────
+// Log panel state per container id: { gen, loading, logs, error }.
+// A closed panel has NO entry — closing deletes it, so re-opening always
+// re-fetches. `gen` is a fetch-generation token: a response is only applied
+// if the entry still carries the token of the fetch that produced it, so a
+// stale in-flight response can never overwrite a newer one.
+const containerLogsState = new Map();
+let containerLogsFetchGen = 0;
+// Container ids with a stop/restart currently in flight (buttons disabled).
+const containerActionsInFlight = new Set();
+
+const CONTAINER_LOG_TAIL = 200;
+
+const CONTAINER_ACTIONS = {
+  stop: { call: (id) => window.api.dockerStop(id), present: 'stop', past: 'Stopped' },
+  restart: { call: (id) => window.api.dockerRestart(id), present: 'restart', past: 'Restarted' },
+};
+
+async function runContainerAction(container, actionKey) {
+  const id = container.id;
+  if (containerActionsInFlight.has(id)) return;
+
+  const action = CONTAINER_ACTIONS[actionKey];
+  containerActionsInFlight.add(id);
+
+  const label = container.name || id.substring(0, 12);
+  try {
+    const result = await action.call(id);
+    if (result && result.success) {
+      showToast(`${action.past} ${label}`, { type: 'success' });
+    } else {
+      const reason = (result && result.error) || 'unknown error';
+      showToast(`Failed to ${action.present} ${label}: ${reason}`, { type: 'error', duration: 5000 });
+    }
+  } catch (err) {
+    showToast(`Failed to ${action.present} ${label}: ${err.message || err}`, { type: 'error', duration: 5000 });
+  } finally {
+    containerActionsInFlight.delete(id);
+    AppState.notify(); // re-enable the buttons without waiting for the next poll
+  }
+}
+
+function applyContainerLogsResult(id, gen, result) {
+  const entry = containerLogsState.get(id);
+  if (!entry || entry.gen !== gen) return; // panel closed, or superseded by a newer fetch
+
+  if (result && result.success) {
+    containerLogsState.set(id, { gen, loading: false, logs: result.logs || '', error: null });
+  } else {
+    const reason = (result && result.error) || 'Could not retrieve logs';
+    containerLogsState.set(id, { gen, loading: false, logs: '', error: reason });
+  }
+  AppState.notify();
+}
+
+function fetchContainerLogs(id) {
+  const gen = ++containerLogsFetchGen;
+  containerLogsState.set(id, { gen, loading: true, logs: '', error: null });
+  AppState.notify();
+
+  window.api.dockerLogs(id, CONTAINER_LOG_TAIL)
+    .then((result) => applyContainerLogsResult(id, gen, result))
+    .catch((err) => applyContainerLogsResult(id, gen, { success: false, error: err.message || String(err) }));
+}
+
+function toggleContainerLogs(id) {
+  if (containerLogsState.has(id)) {
+    containerLogsState.delete(id);
+    AppState.notify();
+    return;
+  }
+  // (Re-)open: always fetch fresh logs.
+  fetchContainerLogs(id);
+}
+
+function renderContainerActions(container) {
+  const inFlight = containerActionsInFlight.has(container.id);
+  const logsOpen = containerLogsState.has(container.id);
+  const label = container.name || container.id.substring(0, 12);
+
+  const stopBtn = h('button', {
+    className: 'btn-profile btn-profile-stop',
+    title: `Stop ${label}`,
+  }, 'Stop');
+  const restartBtn = h('button', {
+    className: 'btn-profile btn-container-restart',
+    title: `Restart ${label}`,
+  }, 'Restart');
+  stopBtn.disabled = inFlight;
+  restartBtn.disabled = inFlight;
+
+  const onAction = (actionKey) => (e) => {
+    e.stopPropagation();
+    // Disable immediately; rebuilt rows re-derive this from the in-flight set.
+    stopBtn.disabled = true;
+    restartBtn.disabled = true;
+    runContainerAction(container, actionKey);
+  };
+  stopBtn.addEventListener('click', onAction('stop'));
+  restartBtn.addEventListener('click', onAction('restart'));
+
+  const logsBtn = h('button', {
+    className: `btn-profile btn-container-logs ${logsOpen ? 'logs-open' : ''}`,
+    title: `Show last ${CONTAINER_LOG_TAIL} log lines for ${label}`,
+  }, 'Logs');
+  logsBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    toggleContainerLogs(container.id);
+  });
+
+  return h('div', { className: 'container-actions' }, [stopBtn, restartBtn, logsBtn]);
+}
+
+// ── Container log row (expandable, reconciler key `ctl:<id>`) ──
+function containerLogSignature(entry) {
+  if (!entry) return 'none';
+  return `${entry.gen}:${entry.loading ? 'loading' : entry.error ? 'error' : 'done'}`;
+}
+
+function populateContainerLogRow(tr, container) {
+  const entry = containerLogsState.get(container.id);
+  const sig = containerLogSignature(entry);
+  // Logs are immutable once fetched — skip the rebuild on poll ticks so the
+  // <pre> keeps its scroll position and text selection.
+  if (tr.__logSig === sig) return;
+  tr.__logSig = sig;
+
+  tr.innerHTML = '';
+  const td = h('td', { className: 'detail-cell' });
+  td.setAttribute('colspan', '6');
+
+  if (!entry || entry.loading) {
+    td.appendChild(h('div', { className: 'detail-panel' }, [
+      h('span', { className: 'detail-loading' }, 'Loading logs...'),
+    ]));
+  } else if (entry.error) {
+    td.appendChild(h('div', { className: 'detail-panel' }, [
+      h('span', { className: 'detail-error' }, `Could not retrieve logs: ${entry.error}`),
+    ]));
+  } else {
+    td.appendChild(h('div', { className: 'detail-panel' }, [
+      h('pre', { className: 'container-logs-pre' }, entry.logs || '(no log output)'),
+    ]));
+  }
+  tr.appendChild(td);
+}
+
+function buildContainerLogRow(container) {
+  const tr = h('tr', { className: 'detail-row container-log-row' });
+  tr.addEventListener('click', (e) => e.stopPropagation());
+  populateContainerLogRow(tr, container);
+  return tr;
+}
+
 function containerThead() {
   return h('thead', {}, [
     h('tr', {}, [
@@ -28,6 +182,7 @@ function containerThead() {
       h('th', { className: 'col-container-status' }, 'Status'),
       h('th', { className: 'col-container-ports' }, 'Ports'),
       h('th', { className: 'col-container-id' }, 'ID'),
+      h('th', { className: 'col-container-actions' }, ''),
     ]),
   ]);
 }
@@ -43,6 +198,7 @@ function populateContainerRow(tr, container) {
   ]));
   tr.appendChild(h('td', { className: 'col-container-ports' }, formatContainerPorts(container.ports)));
   tr.appendChild(h('td', { className: 'col-container-id' }, container.id.substring(0, 12)));
+  tr.appendChild(h('td', { className: 'col-container-actions' }, [renderContainerActions(container)]));
 }
 
 function buildContainerRow(container) {
@@ -82,11 +238,37 @@ function updateContainerSection(section, containers) {
   const body = section.querySelector('.group-body');
   body.classList.toggle('collapsed', isCollapsed);
 
+  if (containerLogsState.size > 0) {
+    if (isCollapsed) {
+      // Collapsing removes the log rows; drop their state so re-expanding
+      // never shows a stale snapshot (re-opening re-fetches).
+      containerLogsState.clear();
+    } else {
+      // Prune log-panel state for containers that no longer exist.
+      const liveIds = new Set(containers.map((c) => c.id));
+      for (const id of containerLogsState.keys()) {
+        if (!liveIds.has(id)) containerLogsState.delete(id);
+      }
+    }
+  }
+
   const tbody = section.querySelector('tbody');
-  const items = isCollapsed ? [] : containers.map((c) => ({
-    key: `ct:${c.id}`,
-    create: () => buildContainerRow(c),
-    update: (el) => populateContainerRow(el, c),
-  }));
+  const items = [];
+  if (!isCollapsed) {
+    for (const c of containers) {
+      items.push({
+        key: `ct:${c.id}`,
+        create: () => buildContainerRow(c),
+        update: (el) => populateContainerRow(el, c),
+      });
+      if (containerLogsState.has(c.id)) {
+        items.push({
+          key: `ctl:${c.id}`,
+          create: () => buildContainerLogRow(c),
+          update: (el) => populateContainerLogRow(el, c),
+        });
+      }
+    }
+  }
   reconcileChildren(tbody, items);
 }

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -1461,3 +1461,54 @@
 .container-restarting {
   color: var(--accent-blue);
 }
+
+/* ── Docker actions ─────────── */
+.col-container-actions {
+  width: 170px;
+  text-align: right;
+}
+
+.container-actions {
+  display: flex;
+  gap: 4px;
+  justify-content: flex-end;
+}
+
+/* Stop reuses .btn-profile-stop; only restart/logs need new variants. */
+.btn-container-restart {
+  border-color: rgba(224, 175, 104, 0.4);
+  color: var(--accent-amber);
+  background: rgba(224, 175, 104, 0.08);
+}
+
+.btn-container-restart:not(:disabled):hover {
+  background: rgba(224, 175, 104, 0.18);
+}
+
+.btn-container-logs {
+  border-color: rgba(122, 162, 247, 0.4);
+  color: var(--accent-blue);
+  background: rgba(122, 162, 247, 0.08);
+}
+
+.btn-container-logs:not(:disabled):hover,
+.btn-container-logs.logs-open {
+  background: rgba(122, 162, 247, 0.18);
+}
+
+.container-logs-pre {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin: 0;
+  max-height: 260px;
+  overflow-y: auto;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}

--- a/test/docker-collector.test.js
+++ b/test/docker-collector.test.js
@@ -1,6 +1,12 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { parseDockerJson, parsePorts } = require('../main/collectors/docker-collector');
+const {
+  parseDockerJson,
+  parsePorts,
+  isValidContainerId,
+  friendlyDockerError,
+  clampTail,
+} = require('../main/collectors/docker-collector');
 
 test('parseDockerJson parses one JSON object per line', () => {
   const output = [
@@ -64,4 +70,77 @@ test('parsePorts parses exposed-but-unbound ports', () => {
 test('parsePorts returns empty array for empty or blank input', () => {
   assert.deepStrictEqual(parsePorts(''), []);
   assert.deepStrictEqual(parsePorts('   '), []);
+});
+
+test('isValidContainerId accepts full and short hex ids', () => {
+  assert.strictEqual(isValidContainerId('abc123def456'), true);
+  assert.strictEqual(
+    isValidContainerId('4e5021d210f65ebe9d0f891f2c7c912d5b1e4c8a9f3b2d1e0c9b8a7f6e5d4c3b'),
+    true
+  );
+});
+
+test('isValidContainerId accepts container names with dots, dashes, underscores', () => {
+  assert.strictEqual(isValidContainerId('my-postgres'), true);
+  assert.strictEqual(isValidContainerId('redis_cache.local'), true);
+  assert.strictEqual(isValidContainerId('Web-App_2.0'), true);
+});
+
+test('isValidContainerId rejects spaces and shell metacharacters', () => {
+  assert.strictEqual(isValidContainerId('abc 123'), false);
+  assert.strictEqual(isValidContainerId('abc;rm -rf /'), false);
+  assert.strictEqual(isValidContainerId('$(whoami)'), false);
+  assert.strictEqual(isValidContainerId('abc`id`'), false);
+  assert.strictEqual(isValidContainerId('abc&def'), false);
+  assert.strictEqual(isValidContainerId('abc|def'), false);
+  // Dashes are legal id characters; the collector passes ids after `--`
+  // so a dash-prefixed value can never be parsed as a docker flag.
+  assert.strictEqual(isValidContainerId('--detach'), true);
+  assert.strictEqual(isValidContainerId('a/b'), false);
+});
+
+test('isValidContainerId rejects empty and non-string values', () => {
+  assert.strictEqual(isValidContainerId(''), false);
+  assert.strictEqual(isValidContainerId(null), false);
+  assert.strictEqual(isValidContainerId(undefined), false);
+  assert.strictEqual(isValidContainerId(123), false);
+  assert.strictEqual(isValidContainerId({}), false);
+});
+
+test('friendlyDockerError maps common docker failures to actionable messages', () => {
+  assert.strictEqual(
+    friendlyDockerError('error during connect: this error may indicate that the docker daemon is not running'),
+    'Docker daemon is not running'
+  );
+  assert.strictEqual(
+    friendlyDockerError('Cannot connect to the Docker daemon at unix:///var/run/docker.sock'),
+    'Docker daemon is not running'
+  );
+  assert.strictEqual(
+    friendlyDockerError('Error response from daemon: No such container: abc123'),
+    'Container no longer exists'
+  );
+  assert.strictEqual(
+    friendlyDockerError('permission denied while trying to connect to the Docker daemon socket'),
+    'Access denied — check Docker permissions'
+  );
+  assert.strictEqual(friendlyDockerError('spawn docker ENOENT'), 'Docker CLI not found');
+});
+
+test('friendlyDockerError falls back to the raw message', () => {
+  assert.strictEqual(friendlyDockerError('some unexpected failure'), 'some unexpected failure');
+  assert.strictEqual(friendlyDockerError('  padded  '), 'padded');
+  assert.strictEqual(friendlyDockerError(''), 'Unknown error');
+  assert.strictEqual(friendlyDockerError(null), 'Unknown error');
+});
+
+test('clampTail clamps invalid or out-of-range tail values to 200', () => {
+  assert.strictEqual(clampTail(50), 50);
+  assert.strictEqual(clampTail(10000), 10000);
+  assert.strictEqual(clampTail(0), 200);
+  assert.strictEqual(clampTail(-5), 200);
+  assert.strictEqual(clampTail(10001), 200);
+  assert.strictEqual(clampTail(3.5), 200);
+  assert.strictEqual(clampTail('200'), 200);
+  assert.strictEqual(clampTail(undefined), 200);
 });


### PR DESCRIPTION
## Summary

Adds per-container **Stop / Restart / Logs** actions to the Containers section (unit U8 of the parallel improvement plan).

### Main process
- `docker-collector.js`: `stopContainer(id)` / `restartContainer(id)` via a shared `runContainerCommand` helper (15 s timeout — `docker stop` waits 10 s by default), and a spawn-based `getLogs(id, tail)` that appends stdout/stderr chunks in **arrival order** so interleaved container output keeps its chronology (capped at 1 MB, 10 s timeout).
- Ids are validated main-side against `/^[a-zA-Z0-9_.-]+$/` (`isValidContainerId`, exported for tests) and passed after `--` so a dash-prefixed value can never be parsed as a docker flag.
- `friendlyDockerError` maps common failures (daemon not running, no such container, permission denied, CLI missing, timeout) to actionable toast messages, mirroring `process-killer.js`.
- `ipc-handlers.js` / `preload.js`: `docker-stop`, `docker-restart`, `docker-logs` channels at the feature anchors; the renderer sends only the container id (+ optional tail) — same trust model as profiles.

### Renderer
- `container-table.js`: new actions cell with Stop/Restart/Logs buttons. Stop/Restart disable while in flight and report via the existing toast pattern. Logs toggles an expandable `<pre>` row (reconciler key `ctl:<id>`, following the process-table detail-row pattern) and re-fetches on every re-open.
- Robustness: a fetch-generation token prevents a stale in-flight logs response from overwriting a newer one; the log row's update is a no-op once content is rendered (preserves scroll position/selection across poll ticks); log-panel state is dropped when the section collapses or a container disappears.
- `components.css`: appended-only `Docker actions` block; Stop reuses the existing `.btn-profile-stop` styling.

### Tests
- `test/docker-collector.test.js`: cases for `isValidContainerId` (valid ids; rejects spaces, `;`, `$( )`, empty, non-strings), `friendlyDockerError`, and `clampTail`. 37 tests pass; lint clean; smoke boot verified (plus a live `docker logs` read against a running container).

### Follow-ups (out of scope for this unit)
- Extract the docker action commands from the collector into a `main/services/docker-controller.js` service (parallel to `process-killer.js`).
- Migrate the log-panel UI state from module-level state in `container-table.js` into `AppState` (`state.js` is owned by a sibling unit in this plan, so it was off-limits here).
