### PR TITLE
Add opt-in local read-only HTTP API (127.0.0.1, GET-only, off by default)

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -9,6 +9,7 @@ const { updateTooltip } = require('./tray-manager');
 const notifier = require('./services/notifier');
 const config = require('./services/config');
 const dockerCollector = require('./collectors/docker-collector');
+const httpApi = require('./services/http-api');
 
 function registerIpcHandlers() {
   // Initialise notifier from saved config
@@ -139,6 +140,10 @@ function registerIpcHandlers() {
     }
     if (key === 'autostart') {
       app.setLoginItemSettings({ openAtLogin: !!value });
+    }
+    if (key === 'httpApiEnabled' || key === 'httpApiPort') {
+      if (updated.httpApiEnabled) httpApi.restart({ getSnapshot: getLastSnapshot, port: updated.httpApiPort });
+      else httpApi.stop();
     }
 
     return updated;

--- a/main/main.js
+++ b/main/main.js
@@ -4,6 +4,8 @@ const { registerIpcHandlers } = require('./ipc-handlers');
 const { createTray, setQuitting, destroy: destroyTray } = require('./tray-manager');
 const notifier = require('./services/notifier');
 const config = require('./services/config');
+const httpApi = require('./services/http-api');
+const { getLastSnapshot } = require('./poll-manager');
 
 let mainWindow;
 
@@ -88,6 +90,11 @@ app.whenReady().then(() => {
       mainWindow.webContents.send('scroll-to-process', pid);
     }
   });
+
+  // Opt-in local read-only HTTP API (off by default)
+  if (config.get('httpApiEnabled')) {
+    httpApi.start({ getSnapshot: getLastSnapshot, port: config.get('httpApiPort') });
+  }
 });
 
 app.on('before-quit', () => {
@@ -109,4 +116,5 @@ app.on('activate', () => {
 
 app.on('will-quit', () => {
   destroyTray();
+  httpApi.stop();
 });

--- a/main/services/config.js
+++ b/main/services/config.js
@@ -22,6 +22,8 @@ const DEFAULTS = {
   hiddenPollInterval: 15,  // seconds (5–120) — poll cadence while the window is hidden
   portHealthChecks: true,  // probe listening ports over HTTP and show up/down status
   userRules: [],           // [{ id, pattern, metric: 'cpu'|'mem', threshold, sustainPolls, action: 'notify'|'kill'|'command', command?, cwd? }]
+  httpApiEnabled: false,   // opt-in local read-only HTTP API
+  httpApiPort: 3999,       // 1024–65535
 };
 
 const VALID_THEMES = ['dark', 'light'];
@@ -113,6 +115,9 @@ function validate(cfg) {
   });
 
   // [anchor: feature validation] — new feature validation clauses go below this line
+  result.httpApiEnabled = !!result.httpApiEnabled;
+  result.httpApiPort = Math.max(1024, Math.min(65535,
+    Math.floor(Number(result.httpApiPort)) || DEFAULTS.httpApiPort));
 
   // hiddenPollInterval: clamp to 5–120
   result.hiddenPollInterval = Math.max(5, Math.min(120, Number(result.hiddenPollInterval) || DEFAULTS.hiddenPollInterval));

--- a/main/services/http-api.js
+++ b/main/services/http-api.js
@@ -1,0 +1,238 @@
+/*
+ * Opt-in local read-only HTTP API.
+ *
+ * Lets same-machine tooling (e.g. coding agents) ask "which ports are busy?
+ * is the DB running?" without driving the UI. GET-only, bound explicitly to
+ * 127.0.0.1, OFF by default (see config keys httpApiEnabled / httpApiPort).
+ *
+ * Plain CommonJS + node:http only — no Electron imports — so it can be unit
+ * tested under bare Node.
+ */
+
+const http = require('node:http');
+
+// Single route registry: drives dispatch, the '/' index, and 404 hints.
+const ROUTES = {
+  '/processes': {
+    description: 'Flattened process list (pid, name, group, cpu, memKB, ports)',
+    handler: (snapshot) => flattenProcesses(snapshot),
+  },
+  '/ports': {
+    description: 'Listening ports ({ port, pid, processName })',
+    handler: (snapshot) => collectPorts(snapshot),
+  },
+  '/containers': {
+    description: 'Docker containers',
+    handler: (snapshot) => snapshot.containers || [],
+  },
+  '/warnings': {
+    description: 'Active warnings',
+    handler: (snapshot) => snapshot.warnings || [],
+  },
+};
+
+let server = null;
+
+// start/stop/restart mutate the module-level `server`; serialize them so a
+// stop() can never close a socket whose 'listening' event hasn't fired yet
+// (which would leave start()'s promise unsettled) and rapid enable/disable
+// toggles from the settings UI can't interleave.
+let opChain = Promise.resolve();
+
+function enqueue(fn) {
+  const result = opChain.then(fn);
+  // The queued ops never reject, but keep the chain safe regardless.
+  opChain = result.then(() => {}, () => {});
+  return result;
+}
+
+function flattenProcesses(snapshot) {
+  const out = [];
+  const groups = snapshot.groups || {};
+  for (const groupKey of Object.keys(groups)) {
+    const group = groups[groupKey] || {};
+    for (const proc of group.processes || []) {
+      out.push({
+        pid: proc.pid,
+        name: proc.name,
+        group: proc.group || group.key || groupKey,
+        cpu: proc.cpu,
+        memKB: proc.memKB,
+        ports: proc.ports || [],
+      });
+    }
+  }
+  return out;
+}
+
+function collectPorts(snapshot) {
+  const out = [];
+  for (const proc of flattenProcesses(snapshot)) {
+    for (const port of proc.ports) {
+      out.push({ port, pid: proc.pid, processName: proc.name });
+    }
+  }
+  return out;
+}
+
+function routeIndex() {
+  const routes = { '/': 'JSON index of routes' };
+  for (const [route, def] of Object.entries(ROUTES)) {
+    routes[route] = def.description;
+  }
+  return { routes };
+}
+
+function sendJson(res, status, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+// The loopback bind keeps remote hosts out, but a malicious web page can
+// still reach us via DNS rebinding (evil.com resolving to 127.0.0.1 makes
+// the browser's fetch same-origin — CORS never applies). Reject any request
+// whose Host header names something other than this machine's loopback.
+function isLocalHostHeader(host) {
+  if (!host) return true; // raw local clients (no Host header) are fine
+  const name = host.replace(/:\d+$/, '').toLowerCase();
+  return name === '127.0.0.1' || name === 'localhost' || name === '[::1]';
+}
+
+function handleRequest(getSnapshot, req, res) {
+  if (req.method !== 'GET') {
+    sendJson(res, 405, { error: 'GET only' });
+    return;
+  }
+
+  if (!isLocalHostHeader(req.headers.host)) {
+    sendJson(res, 403, { error: 'Forbidden' });
+    return;
+  }
+
+  let pathname;
+  try {
+    pathname = new URL(req.url, 'http://127.0.0.1').pathname;
+  } catch {
+    pathname = null;
+  }
+
+  if (pathname === '/') {
+    sendJson(res, 200, routeIndex());
+    return;
+  }
+
+  const route = pathname ? ROUTES[pathname] : null;
+  if (!route) {
+    sendJson(res, 404, { error: 'Not found', routes: Object.keys(ROUTES) });
+    return;
+  }
+
+  let snapshot;
+  try {
+    snapshot = typeof getSnapshot === 'function' ? getSnapshot() : null;
+  } catch {
+    snapshot = null;
+  }
+  if (!snapshot) {
+    sendJson(res, 503, { error: 'no snapshot yet' });
+    return;
+  }
+
+  sendJson(res, 200, route.handler(snapshot));
+}
+
+function doStart({ getSnapshot, port } = {}) {
+  return new Promise((resolve) => {
+    try {
+      if (server) {
+        // Already running — no-op. Ops are serialized, so the previous
+        // start has fully bound and address() is available. Use restart()
+        // to apply new options.
+        const addr = server.address();
+        resolve(addr ? addr.port : null);
+        return;
+      }
+
+      const srv = http.createServer((req, res) => {
+        try {
+          handleRequest(getSnapshot, req, res);
+        } catch (err) {
+          try {
+            sendJson(res, 500, { error: err.message });
+          } catch {
+            /* response already gone */
+          }
+        }
+      });
+
+      srv.on('error', (err) => {
+        console.warn(`[http-api] server error (${err.code || err.message}) — API disabled`);
+        if (server === srv) server = null;
+        try {
+          srv.close();
+        } catch {
+          /* already closed */
+        }
+        resolve(null);
+      });
+
+      server = srv;
+      // Bind explicitly to loopback: never reachable from the network.
+      srv.listen(port, '127.0.0.1', () => {
+        resolve(srv.address().port);
+      });
+    } catch (err) {
+      console.warn(`[http-api] failed to start: ${err.message}`);
+      server = null;
+      resolve(null);
+    }
+  });
+}
+
+function doStop() {
+  return new Promise((resolve) => {
+    if (!server) {
+      resolve();
+      return;
+    }
+    const srv = server;
+    server = null;
+    try {
+      srv.close(() => resolve());
+      // Drop keep-alive connections so close() doesn't hang.
+      if (typeof srv.closeAllConnections === 'function') {
+        srv.closeAllConnections();
+      }
+    } catch {
+      resolve();
+    }
+  });
+}
+
+/**
+ * Start the API server. Never throws or rejects; resolves with the bound
+ * port (useful when passing port 0 in tests), or null if the server could
+ * not be started (e.g. EADDRINUSE).
+ */
+function start(opts) {
+  return enqueue(() => doStart(opts));
+}
+
+/** Stop the server if running. Never throws; resolves when closed. */
+function stop() {
+  return enqueue(() => doStop());
+}
+
+/** Restart with new options (e.g. after a port change in settings). */
+function restart(opts) {
+  return enqueue(async () => {
+    await doStop();
+    return doStart(opts);
+  });
+}
+
+module.exports = { start, stop, restart };

--- a/renderer/js/components/settings.js
+++ b/renderer/js/components/settings.js
@@ -131,6 +131,8 @@ function renderSettingsBody() {
 
   // ── Rules (rule engine) ────────────────────────────
   body.appendChild(renderSection('Rules', renderUserRules()));
+  // ── Local HTTP API ─────────────────────────────────
+  body.appendChild(renderSection('Local HTTP API', renderHttpApi()));
 }
 
 function renderSection(title, content) {
@@ -744,6 +746,44 @@ function renderUserRules() {
   ]));
   form.appendChild(commandRow);
   wrapper.appendChild(form);
+
+  return wrapper;
+}
+
+// ── Local HTTP API ─────────────────────────────────────────
+function renderHttpApi() {
+  const wrapper = h('div', { className: 'settings-http-api' });
+
+  wrapper.appendChild(h('p', { className: 'settings-hint' },
+    'Read-only JSON API for local tooling (e.g. coding agents). GET-only, bound to 127.0.0.1 — never reachable from the network.'));
+
+  wrapper.appendChild(renderToggle(
+    'httpApiEnabled',
+    'Enable local read-only API',
+    !!settingsConfig.httpApiEnabled,
+  ));
+
+  const portInput = h('input', {
+    type: 'number', min: '1024', max: '65535', step: '1',
+    className: 'settings-threshold-input',
+  });
+  portInput.value = settingsConfig.httpApiPort;
+  portInput.addEventListener('change', () => {
+    // Main-process config validation clamps/defaults invalid values;
+    // the settings body re-renders with the validated result.
+    updateSetting('httpApiPort', Number(portInput.value));
+  });
+
+  wrapper.appendChild(h('div', { className: 'settings-threshold-row' }, [
+    h('label', {}, 'Port'), portInput,
+  ]));
+
+  if (settingsConfig.httpApiEnabled) {
+    wrapper.appendChild(h('p', { className: 'settings-hint' }, [
+      'Try: ',
+      h('code', {}, `http://127.0.0.1:${settingsConfig.httpApiPort}/processes`),
+    ]));
+  }
 
   return wrapper;
 }

--- a/test/http-api.test.js
+++ b/test/http-api.test.js
@@ -1,0 +1,224 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+// http-api.js is Electron-free by design, so no module stubbing is needed.
+const httpApi = require('../main/services/http-api');
+
+const fakeSnapshot = {
+  groups: {
+    dev: {
+      key: 'dev',
+      icon: 'code',
+      label: 'Dev Processes',
+      order: 0,
+      processes: [
+        { pid: 100, name: 'node.exe', memKB: 204800, cpu: 12.5, started: 'x', ports: [3000, 3001], portDetails: [], group: 'dev', hasWarning: false },
+        { pid: 101, name: 'vite.exe', memKB: 51200, cpu: 3.1, started: 'x', ports: [], portDetails: [], group: 'dev', hasWarning: false },
+      ],
+      totalCpu: 15.6,
+      totalMemKB: 256000,
+    },
+    databases: {
+      key: 'databases',
+      icon: 'db',
+      label: 'Databases',
+      order: 1,
+      processes: [
+        { pid: 200, name: 'postgres.exe', memKB: 409600, cpu: 1.2, started: 'x', ports: [5432], portDetails: [], group: 'databases', hasWarning: true },
+      ],
+      totalCpu: 1.2,
+      totalMemKB: 409600,
+    },
+  },
+  containers: [
+    { id: 'abc123', name: 'my-db', image: 'postgres:16', status: 'Up 2 hours', state: 'running', ports: ['5432:5432'], matchedPorts: [5432] },
+  ],
+  warnings: [{ type: 'port-conflict', port: 3000 }],
+  timestamp: 1234567890,
+  totalProcesses: 3,
+};
+
+function request(port, path, method = 'GET', headers = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path, method, headers },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => {
+          let json = null;
+          try {
+            json = JSON.parse(body);
+          } catch {
+            /* leave null */
+          }
+          resolve({ status: res.statusCode, json });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+// Start on an ephemeral port with a fake snapshot; always stop after.
+async function withServer(getSnapshot, fn) {
+  const port = await httpApi.start({ getSnapshot, port: 0 });
+  assert.ok(typeof port === 'number' && port > 0, 'start() resolves the bound ephemeral port');
+  try {
+    await fn(port);
+  } finally {
+    await httpApi.stop();
+  }
+}
+
+test('GET /processes flattens processes across groups', async () => {
+  await withServer(() => fakeSnapshot, async (port) => {
+    const { status, json } = await request(port, '/processes');
+    assert.strictEqual(status, 200);
+    assert.ok(Array.isArray(json));
+    assert.strictEqual(json.length, 3);
+
+    const byPid = Object.fromEntries(json.map((p) => [p.pid, p]));
+    assert.deepStrictEqual(byPid[100], {
+      pid: 100, name: 'node.exe', group: 'dev', cpu: 12.5, memKB: 204800, ports: [3000, 3001],
+    });
+    assert.deepStrictEqual(byPid[200], {
+      pid: 200, name: 'postgres.exe', group: 'databases', cpu: 1.2, memKB: 409600, ports: [5432],
+    });
+    // Only the flattened fields are exposed — no started/portDetails/hasWarning.
+    assert.deepStrictEqual(
+      Object.keys(byPid[101]).sort(),
+      ['cpu', 'group', 'memKB', 'name', 'pid', 'ports']
+    );
+  });
+});
+
+test('GET /ports returns one entry per (process, port) pair', async () => {
+  await withServer(() => fakeSnapshot, async (port) => {
+    const { status, json } = await request(port, '/ports');
+    assert.strictEqual(status, 200);
+    assert.ok(Array.isArray(json));
+
+    const sorted = [...json].sort((a, b) => a.port - b.port);
+    assert.deepStrictEqual(sorted, [
+      { port: 3000, pid: 100, processName: 'node.exe' },
+      { port: 3001, pid: 100, processName: 'node.exe' },
+      { port: 5432, pid: 200, processName: 'postgres.exe' },
+    ]);
+  });
+});
+
+test('GET /containers and /warnings pass through the snapshot arrays', async () => {
+  await withServer(() => fakeSnapshot, async (port) => {
+    const containers = await request(port, '/containers');
+    assert.strictEqual(containers.status, 200);
+    assert.deepStrictEqual(containers.json, fakeSnapshot.containers);
+
+    const warnings = await request(port, '/warnings');
+    assert.strictEqual(warnings.status, 200);
+    assert.deepStrictEqual(warnings.json, fakeSnapshot.warnings);
+  });
+});
+
+test('GET / returns a JSON index of routes', async () => {
+  await withServer(() => fakeSnapshot, async (port) => {
+    const { status, json } = await request(port, '/');
+    assert.strictEqual(status, 200);
+    assert.ok(json.routes);
+    for (const route of ['/processes', '/ports', '/containers', '/warnings']) {
+      assert.ok(route in json.routes, `index lists ${route}`);
+    }
+  });
+});
+
+test('unknown routes return 404', async () => {
+  await withServer(() => fakeSnapshot, async (port) => {
+    const { status, json } = await request(port, '/nope');
+    assert.strictEqual(status, 404);
+    assert.ok(json.error);
+  });
+});
+
+test('non-GET methods return 405', async () => {
+  await withServer(() => fakeSnapshot, async (port) => {
+    const post = await request(port, '/processes', 'POST');
+    assert.strictEqual(post.status, 405);
+
+    const del = await request(port, '/ports', 'DELETE');
+    assert.strictEqual(del.status, 405);
+  });
+});
+
+test('rejects non-local Host headers (DNS rebinding guard)', async () => {
+  await withServer(() => fakeSnapshot, async (port) => {
+    const evil = await request(port, '/processes', 'GET', { Host: 'evil.example.com:3999' });
+    assert.strictEqual(evil.status, 403);
+
+    const local = await request(port, '/processes', 'GET', { Host: `localhost:${port}` });
+    assert.strictEqual(local.status, 200);
+  });
+});
+
+test('returns 503 when no snapshot is available yet', async () => {
+  await withServer(() => null, async (port) => {
+    const { status, json } = await request(port, '/processes');
+    assert.strictEqual(status, 503);
+    assert.strictEqual(json.error, 'no snapshot yet');
+  });
+});
+
+test('stop() actually closes the server', async () => {
+  const port = await httpApi.start({ getSnapshot: () => fakeSnapshot, port: 0 });
+  assert.ok(port > 0);
+
+  const before = await request(port, '/processes');
+  assert.strictEqual(before.status, 200);
+
+  await httpApi.stop();
+
+  await assert.rejects(
+    request(port, '/processes'),
+    (err) => err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET',
+    'requests fail after stop()'
+  );
+});
+
+test('restart() moves the server and never throws on stop of a stopped server', async () => {
+  const portA = await httpApi.start({ getSnapshot: () => fakeSnapshot, port: 0 });
+  const portB = await httpApi.restart({ getSnapshot: () => fakeSnapshot, port: 0 });
+  assert.ok(portB > 0);
+
+  const res = await request(portB, '/processes');
+  assert.strictEqual(res.status, 200);
+
+  await httpApi.stop();
+  await httpApi.stop(); // idempotent
+
+  if (portA !== portB) {
+    await assert.rejects(request(portA, '/processes'));
+  }
+});
+
+test('overlapping start/stop/restart calls are serialized and all settle', async () => {
+  // Fire without awaiting — mimics the fire-and-forget IPC side-effects
+  // when the user toggles the API rapidly in settings.
+  const p1 = httpApi.start({ getSnapshot: () => fakeSnapshot, port: 0 });
+  const p2 = httpApi.stop();
+  const p3 = httpApi.restart({ getSnapshot: () => fakeSnapshot, port: 0 });
+  const p4 = httpApi.stop();
+  const p5 = httpApi.start({ getSnapshot: () => fakeSnapshot, port: 0 });
+
+  const [r1, , r3, , r5] = await Promise.all([p1, p2, p3, p4, p5]);
+  assert.ok(r1 > 0, 'first start binds');
+  assert.ok(r3 > 0, 'restart after stop binds');
+  assert.ok(r5 > 0, 'final start binds');
+
+  // The last operation to run wins: the server from p5 is live.
+  const res = await request(r5, '/processes');
+  assert.strictEqual(res.status, 200);
+
+  await httpApi.stop();
+  await assert.rejects(request(r5, '/processes'));
+});


### PR DESCRIPTION
## Summary
- New `main/services/http-api.js`: Electron-free `node:http` server exposing read-only JSON for local tooling (e.g. Claude Code asking "which ports are busy? is the DB running?").
- Routes: `/` (index), `/processes` (flattened across groups: pid, name, group, cpu, memKB, ports), `/ports` (`{port, pid, processName}`), `/containers`, `/warnings`. 404 otherwise, 405 on non-GET, 503 before the first poll snapshot.
- Bound explicitly to `127.0.0.1`; no CORS headers; Host-header check rejects DNS-rebinding requests with 403.
- `start`/`stop`/`restart` are serialized internally so rapid settings toggles cannot race the socket; `EADDRINUSE` logs a warning instead of crashing and `start()` never throws.
- Config: `httpApiEnabled` (default **false**) and `httpApiPort` (default 3999, clamped 1024–65535) added at the feature anchors in `config.js`.
- Wiring: started in `whenReady` when enabled (reuses `getLastSnapshot` from poll-manager), stopped in `will-quit`; `set-config` restarts/stops it when the two keys change.
- Settings UI: new "Local HTTP API" section with toggle, port input, and a `http://127.0.0.1:<port>/processes` hint when enabled.

## Known limitation
If the configured port is already in use, the failure is logged to the main-process console only; the toggle still shows ON. Surfacing this in the UI needs new IPC surface, deliberately out of scope for this unit.

## Test plan
- [x] `npm test` — 41/41 pass, including new `test/http-api.test.js` (ephemeral port, fake snapshot): flattening, /ports shape, 404, 405, 503, Host-header 403, stop() closes, overlapping start/stop/restart all settle.
- [x] `npm run lint` clean.
- [x] Smoke boot: app alive after 15 s with no exceptions (API off by default).
