### PR TITLE
Auto-generated profile suggestions from a folder scan

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -230,6 +230,28 @@ function registerIpcHandlers() {
       return { success: false, error: err.message, events: [] };
     }
   });
+
+  // ── Profile suggestions ──────────────────────────────────────
+  // Pick a folder, scan it for projects (package.json / docker-compose)
+  // and return suggested service profiles.
+  ipcMain.handle('scan-profile-suggestions', async () => {
+    const win = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
+    const res = await dialog.showOpenDialog(win, {
+      title: 'Scan folder for project suggestions',
+      properties: ['openDirectory'],
+    });
+    if (res.canceled || !res.filePaths || !res.filePaths[0]) {
+      return { success: false, canceled: true };
+    }
+
+    try {
+      const { scan } = require('./services/profile-scanner');
+      const suggestions = scan(res.filePaths[0]);
+      return { success: true, suggestions };
+    } catch (err) {
+      return { success: false, error: err.message };
+    }
+  });
 }
 
 module.exports = { registerIpcHandlers };

--- a/main/preload.js
+++ b/main/preload.js
@@ -40,4 +40,7 @@ contextBridge.exposeInMainWorld('api', {
 
   // ── Event history
   getEventHistory: (limit) => ipcRenderer.invoke('get-event-history', limit),
+
+  // ── Profile suggestions ──────────────────────────────────────
+  scanProfileSuggestions: () => ipcRenderer.invoke('scan-profile-suggestions'),
 });

--- a/main/services/profile-scanner.js
+++ b/main/services/profile-scanner.js
@@ -1,0 +1,175 @@
+/*
+ * Profile scanner — walks a folder for projects and suggests service profiles.
+ *
+ * Electron-free CommonJS module (runs under plain Node in CI). The `fs`
+ * dependency is injectable for tests; only `readdirSync(dir, { withFileTypes })`
+ * and `readFileSync(file, 'utf8')` are used.
+ */
+
+const path = require('path');
+
+const MAX_DEPTH = 2; // rootDir = depth 0, children = 1, grandchildren = 2
+const MAX_SUGGESTIONS = 50;
+const MAX_DIRS = 2000; // hard walk budget — bounds I/O on huge/slow trees
+
+// Directories never worth descending into
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  'vendor',
+  'target',
+  'tmp',
+  'temp',
+]);
+
+const COMPOSE_FILES = ['docker-compose.yml', 'docker-compose.yaml', 'compose.yaml'];
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function shouldSkipDir(name) {
+  return name.startsWith('.') || SKIP_DIRS.has(name.toLowerCase());
+}
+
+// ── package.json ─────────────────────────────────────────────
+
+function suggestFromPackageJson(raw, dir) {
+  let pkg;
+  try {
+    pkg = JSON.parse(raw);
+  } catch {
+    return null; // broken JSON — skip silently
+  }
+  if (!pkg || typeof pkg !== 'object') return null;
+
+  const scripts = pkg.scripts;
+  if (!scripts || typeof scripts !== 'object') return null;
+
+  const baseName = (typeof pkg.name === 'string' && pkg.name.trim())
+    ? pkg.name.trim()
+    : (path.basename(dir) || dir);
+
+  if (typeof scripts.dev === 'string' && scripts.dev.trim()) {
+    return { name: `${baseName} (dev)`, command: 'npm run dev', cwd: dir, pattern: 'node' };
+  }
+  if (typeof scripts.start === 'string' && scripts.start.trim()) {
+    return { name: `${baseName} (start)`, command: 'npm start', cwd: dir, pattern: 'node' };
+  }
+  return null;
+}
+
+// ── docker-compose ───────────────────────────────────────────
+
+// Extract top-level service names from a compose file without a YAML parser:
+// find the unindented `services:` line, then collect keys indented exactly
+// two spaces until the next unindented line.
+function extractComposeServices(raw) {
+  const services = [];
+  const lines = String(raw).split(/\r?\n/);
+
+  let inServices = false;
+  for (const line of lines) {
+    if (!inServices) {
+      if (/^services:\s*(#.*)?$/.test(line)) inServices = true;
+      continue;
+    }
+
+    // Blank lines and comment lines never terminate the block
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+
+    // A new unindented top-level key ends the services block
+    if (!/^[ \t]/.test(line)) break;
+
+    // Service keys are indented exactly 2 spaces and end with ':'
+    const m = line.match(/^ {2}([A-Za-z0-9][A-Za-z0-9._-]*):\s*(#.*)?$/);
+    if (m) services.push(m[1]);
+    // Anything else (deeper indentation = service properties) is ignored
+  }
+
+  return services;
+}
+
+function suggestFromCompose(raw, dir) {
+  const dirName = path.basename(dir) || dir;
+  return extractComposeServices(raw).map((svc) => ({
+    name: `${dirName} – ${svc}`,
+    command: `docker compose up ${svc}`,
+    cwd: dir,
+    pattern: escapeRegex(svc),
+  }));
+}
+
+// ── Directory walk ───────────────────────────────────────────
+
+function scan(rootDir, { fs = require('fs') } = {}) {
+  const suggestions = [];
+  const seen = new Set();
+  let visitedDirs = 0;
+
+  const add = (suggestion) => {
+    if (!suggestion || suggestions.length >= MAX_SUGGESTIONS) return;
+    const key = `${suggestion.command}::${suggestion.cwd}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    suggestions.push(suggestion);
+  };
+
+  const readFile = (file) => {
+    try {
+      return fs.readFileSync(file, 'utf8');
+    } catch {
+      return null; // unreadable — skip silently
+    }
+  };
+
+  const walk = (dir, depth) => {
+    if (suggestions.length >= MAX_SUGGESTIONS) return;
+    if (visitedDirs >= MAX_DIRS) return;
+    visitedDirs++;
+
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // unreadable directory — skip silently
+    }
+
+    const names = new Set(entries.map((e) => e.name));
+
+    if (names.has('package.json')) {
+      const raw = readFile(path.join(dir, 'package.json'));
+      if (raw !== null) add(suggestFromPackageJson(raw, dir));
+    }
+
+    for (const composeName of COMPOSE_FILES) {
+      if (!names.has(composeName)) continue;
+      const raw = readFile(path.join(dir, composeName));
+      if (raw === null) continue;
+      for (const suggestion of suggestFromCompose(raw, dir)) {
+        add(suggestion);
+      }
+    }
+
+    if (depth >= MAX_DEPTH) return;
+
+    for (const entry of entries) {
+      let isDir;
+      try {
+        isDir = entry.isDirectory();
+      } catch {
+        continue;
+      }
+      if (!isDir || shouldSkipDir(entry.name)) continue;
+      walk(path.join(dir, entry.name), depth + 1);
+    }
+  };
+
+  walk(rootDir, 0);
+  return suggestions;
+}
+
+module.exports = { scan, extractComposeServices };

--- a/renderer/js/components/settings.js
+++ b/renderer/js/components/settings.js
@@ -388,7 +388,6 @@ function renderProfiles() {
   if (profiles.length === 0) {
     wrapper.appendChild(h('p', { className: 'settings-profiles-empty' },
       'No profiles yet. Right-click any process to add it to a profile.'));
-    return wrapper;
   }
 
   for (let pi = 0; pi < profiles.length; pi++) {
@@ -481,5 +480,121 @@ function renderProfiles() {
     wrapper.appendChild(card);
   }
 
+  wrapper.appendChild(renderProfileSuggestions(profiles));
+
+  return wrapper;
+}
+
+// ── Profile suggestions (auto-generated from a folder scan) ──
+// State survives body re-renders while the panel is open.
+let pendingProfileSuggestions = null; // null = hidden, [] = scan found nothing
+
+function renderProfileSuggestions(profiles) {
+  // Reset the pending scan whenever the settings modal closes so a stale
+  // panel does not reappear on the next open. (closeSettings is shared code
+  // owned outside this section, so observe the modal instead of editing it.)
+  const modal = document.getElementById('settings-modal');
+  if (modal && !modal.dataset.suggestionsObserved) {
+    modal.dataset.suggestionsObserved = '1';
+    new MutationObserver(() => {
+      if (modal.classList.contains('hidden')) pendingProfileSuggestions = null;
+    }).observe(modal, { attributes: true, attributeFilter: ['class'] });
+  }
+
+  const wrapper = h('div', { className: 'profile-suggestions' });
+
+  const importBtn = h('button', {
+    className: 'btn btn-secondary profile-suggestions-import',
+    onClick: async () => {
+      const res = await window.api.scanProfileSuggestions();
+      if (!res || res.canceled) return;
+      if (!res.success) {
+        showError(res.error || 'Failed to scan folder');
+        return;
+      }
+      pendingProfileSuggestions = res.suggestions || [];
+      renderSettingsBody();
+    },
+  }, 'Import suggestions…');
+  wrapper.appendChild(importBtn);
+
+  if (pendingProfileSuggestions === null) return wrapper;
+
+  const panel = h('div', { className: 'profile-suggestions-panel' });
+
+  const closePanel = () => {
+    pendingProfileSuggestions = null;
+    renderSettingsBody();
+  };
+
+  if (pendingProfileSuggestions.length === 0) {
+    panel.appendChild(h('p', { className: 'settings-profiles-empty' },
+      'No projects found in the selected folder.'));
+    panel.appendChild(h('div', { className: 'profile-suggestions-actions' }, [
+      h('button', { className: 'btn btn-secondary', onClick: closePanel }, 'Close'),
+    ]));
+    wrapper.appendChild(panel);
+    return wrapper;
+  }
+
+  panel.appendChild(h('p', { className: 'settings-hint' },
+    'Select the services to import as a new profile.'));
+
+  const checkboxes = [];
+  const list = h('div', { className: 'profile-suggestions-list' });
+  for (const suggestion of pendingProfileSuggestions) {
+    const checkbox = h('input', { type: 'checkbox', className: 'profile-suggestion-check' });
+    checkbox.checked = true;
+    checkboxes.push({ checkbox, suggestion });
+
+    const label = h('label', { className: 'profile-suggestion-row' }, [
+      checkbox,
+      h('span', { className: 'profile-suggestion-name' }, suggestion.name),
+      h('code', { className: 'profile-suggestion-cmd' }, suggestion.command),
+      h('span', { className: 'profile-suggestion-cwd', title: suggestion.cwd }, suggestion.cwd),
+    ]);
+    list.appendChild(label);
+  }
+  panel.appendChild(list);
+
+  const confirmBtn = h('button', {
+    className: 'btn btn-secondary profile-suggestions-confirm',
+    onClick: () => {
+      const selected = checkboxes
+        .filter(({ checkbox }) => checkbox.checked)
+        .map(({ suggestion }) => suggestion);
+      if (selected.length === 0) {
+        closePanel();
+        return;
+      }
+
+      // Deterministic ids: the profile gets the timestamp and each service
+      // gets timestamp + index, so ids are unique within this import.
+      // (context-menu.js makeServiceEntry mints one id per user action and
+      // can afford randomness; a batch cannot.)
+      const now = Date.now();
+      const profile = {
+        id: String(now),
+        name: 'Imported suggestions',
+        services: selected.map((s, i) => ({
+          id: String(now + i + 1),
+          name: s.name,
+          pattern: s.pattern,
+          command: s.command,
+          cwd: s.cwd,
+        })),
+      };
+
+      pendingProfileSuggestions = null;
+      updateSetting('profiles', [...profiles, profile]);
+    },
+  }, 'Add selected');
+
+  panel.appendChild(h('div', { className: 'profile-suggestions-actions' }, [
+    confirmBtn,
+    h('button', { className: 'btn btn-secondary', onClick: closePanel }, 'Cancel'),
+  ]));
+
+  wrapper.appendChild(panel);
   return wrapper;
 }

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -1948,6 +1948,52 @@
 
 .timeline-text {
   flex: 1;
+/* ── Profile suggestions ─────────── */
+.profile-suggestions {
+  margin-top: 10px;
+}
+
+.profile-suggestions-import {
+  font-size: 12px;
+}
+
+.profile-suggestions-panel {
+  margin-top: 8px;
+  padding: 10px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  border-radius: 6px;
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.03));
+}
+
+.profile-suggestions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+  margin: 8px 0;
+}
+
+.profile-suggestion-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.profile-suggestion-row:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.05));
+}
+
+.profile-suggestion-check {
+  flex: none;
+}
+
+.profile-suggestion-name {
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1975,4 +2021,26 @@
   flex-shrink: 0;
   color: var(--text-secondary);
   font-size: 11px;
+.profile-suggestion-cmd {
+  flex: none;
+  font-size: 11px;
+  opacity: 0.85;
+}
+
+.profile-suggestion-cwd {
+  flex: 0 1 40%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  text-align: left;
+  font-size: 11px;
+  opacity: 0.6;
+}
+
+.profile-suggestions-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
 }

--- a/test/profile-scanner.test.js
+++ b/test/profile-scanner.test.js
@@ -1,0 +1,241 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+const { scan, extractComposeServices } = require('../main/services/profile-scanner');
+
+// ── Fake fs ──────────────────────────────────────────────────
+// Build an injectable fs from a nested object tree: string values are file
+// contents, object values are directories. Paths are normalised so the
+// scanner's path.join output (\ on Windows, / on POSIX) resolves either way.
+
+const ROOT = path.join('C:', 'projects');
+
+function makeFakeFs(tree) {
+  const lookup = (p) => {
+    const rel = path.relative(ROOT, p);
+    if (rel.startsWith('..')) return undefined;
+    let node = tree;
+    if (rel === '') return node;
+    for (const part of rel.split(/[\\/]+/)) {
+      if (node === null || typeof node !== 'object') return undefined;
+      node = node[part];
+      if (node === undefined) return undefined;
+    }
+    return node;
+  };
+
+  return {
+    readdirSync(dir, opts = {}) {
+      const node = lookup(dir);
+      if (node === null || typeof node !== 'object') {
+        throw new Error(`ENOTDIR: ${dir}`);
+      }
+      assert.ok(opts.withFileTypes, 'scanner should request Dirent entries');
+      return Object.keys(node).map((name) => ({
+        name,
+        isDirectory: () => node[name] !== null && typeof node[name] === 'object',
+      }));
+    },
+    readFileSync(file) {
+      const node = lookup(file);
+      if (typeof node !== 'string') throw new Error(`ENOENT: ${file}`);
+      return node;
+    },
+  };
+}
+
+const pkg = (obj) => JSON.stringify(obj);
+
+// ── package.json suggestions ─────────────────────────────────
+
+test('suggests npm run dev when scripts.dev exists', () => {
+  const fs = makeFakeFs({
+    api: { 'package.json': pkg({ name: 'my-api', scripts: { dev: 'vite', start: 'node .' } }) },
+  });
+  const result = scan(ROOT, { fs });
+  assert.deepStrictEqual(result, [{
+    name: 'my-api (dev)',
+    command: 'npm run dev',
+    cwd: path.join(ROOT, 'api'),
+    pattern: 'node',
+  }]);
+});
+
+test('falls back to npm start when only scripts.start exists', () => {
+  const fs = makeFakeFs({
+    web: { 'package.json': pkg({ name: 'web-app', scripts: { start: 'node server.js' } }) },
+  });
+  const result = scan(ROOT, { fs });
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].name, 'web-app (start)');
+  assert.strictEqual(result[0].command, 'npm start');
+});
+
+test('ignores package.json without dev or start scripts', () => {
+  const fs = makeFakeFs({
+    lib: { 'package.json': pkg({ name: 'lib', scripts: { test: 'node --test' } }) },
+    plain: { 'package.json': pkg({ name: 'plain' }) },
+  });
+  assert.deepStrictEqual(scan(ROOT, { fs }), []);
+});
+
+test('uses directory name when package.json has no name', () => {
+  const fs = makeFakeFs({
+    unnamed: { 'package.json': pkg({ scripts: { dev: 'next dev' } }) },
+  });
+  assert.strictEqual(scan(ROOT, { fs })[0].name, 'unnamed (dev)');
+});
+
+test('tolerates broken JSON and unreadable files', () => {
+  const fs = makeFakeFs({
+    broken: { 'package.json': '{ not: valid json' },
+    ok: { 'package.json': pkg({ name: 'ok', scripts: { dev: 'x' } }) },
+  });
+  // Unreadable file: readFileSync throws for directories-as-files
+  const result = scan(ROOT, { fs });
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].name, 'ok (dev)');
+});
+
+test('tolerates an unreadable root directory', () => {
+  const fs = {
+    readdirSync() { throw new Error('EACCES'); },
+    readFileSync() { throw new Error('EACCES'); },
+  };
+  assert.deepStrictEqual(scan(ROOT, { fs }), []);
+});
+
+// ── docker-compose suggestions ───────────────────────────────
+
+test('extracts multiple compose services with comments and deep indentation ignored', () => {
+  const compose = [
+    'version: "3"',
+    '# top comment',
+    'services:',
+    '  web:',
+    '    image: nginx',
+    '    ports:',
+    '      - "80:80"',
+    '',
+    '  # a comment inside the block',
+    '  db:',
+    '    image: postgres',
+    '    environment:',
+    '      POSTGRES_PASSWORD: x',
+    'volumes:',
+    '  data:',
+  ].join('\n');
+
+  assert.deepStrictEqual(extractComposeServices(compose), ['web', 'db']);
+
+  const fs = makeFakeFs({ stack: { 'docker-compose.yml': compose } });
+  const result = scan(ROOT, { fs });
+  assert.deepStrictEqual(result.map((s) => s.command), [
+    'docker compose up web',
+    'docker compose up db',
+  ]);
+  assert.strictEqual(result[0].name, 'stack – web');
+  assert.strictEqual(result[0].pattern, 'web');
+  assert.strictEqual(result[0].cwd, path.join(ROOT, 'stack'));
+});
+
+test('deeper-nested keys under services are not treated as services', () => {
+  const compose = [
+    'services:',
+    '  app:',
+    '    depends_on:',
+    '      db:',
+    '        condition: service_healthy',
+    '   weird:',
+    '\tenv:',
+  ].join('\n');
+  assert.deepStrictEqual(extractComposeServices(compose), ['app']);
+});
+
+test('supports compose.yaml and docker-compose.yaml names', () => {
+  const fs = makeFakeFs({
+    a: { 'compose.yaml': 'services:\n  one:\n    image: x\n' },
+    b: { 'docker-compose.yaml': 'services:\n  two:\n    image: x\n' },
+  });
+  assert.deepStrictEqual(scan(ROOT, { fs }).map((s) => s.pattern).sort(), ['one', 'two']);
+});
+
+test('compose file without a services block yields nothing', () => {
+  const fs = makeFakeFs({ x: { 'docker-compose.yml': 'volumes:\n  data:\n' } });
+  assert.deepStrictEqual(scan(ROOT, { fs }), []);
+});
+
+// ── walking rules ────────────────────────────────────────────
+
+test('skips node_modules, dot-directories and junk dirs', () => {
+  const devPkg = (name) => ({ 'package.json': pkg({ name, scripts: { dev: 'x' } }) });
+  const fs = makeFakeFs({
+    node_modules: { dep: devPkg('dep') },
+    '.git': devPkg('git-thing'),
+    dist: devPkg('dist-thing'),
+    build: devPkg('build-thing'),
+    real: devPkg('real-app'),
+  });
+  const result = scan(ROOT, { fs });
+  assert.deepStrictEqual(result.map((s) => s.name), ['real-app (dev)']);
+});
+
+test('respects the depth limit of 2', () => {
+  const fs = makeFakeFs({
+    'package.json': pkg({ name: 'root', scripts: { dev: 'x' } }), // depth 0
+    d1: {
+      'package.json': pkg({ name: 'one', scripts: { dev: 'x' } }), // depth 1
+      d2: {
+        'package.json': pkg({ name: 'two', scripts: { dev: 'x' } }), // depth 2
+        d3: {
+          'package.json': pkg({ name: 'three', scripts: { dev: 'x' } }), // depth 3 — too deep
+        },
+      },
+    },
+  });
+  const names = scan(ROOT, { fs }).map((s) => s.name).sort();
+  assert.deepStrictEqual(names, ['one (dev)', 'root (dev)', 'two (dev)']);
+});
+
+test('dedupes identical suggestions and caps at 50', () => {
+  // Same dir yields both docker-compose.yml and compose.yaml with the same
+  // service — deduped by command+cwd.
+  const dupFs = makeFakeFs({
+    dup: {
+      'docker-compose.yml': 'services:\n  api:\n    image: x\n',
+      'compose.yaml': 'services:\n  api:\n    image: y\n',
+    },
+  });
+  assert.strictEqual(scan(ROOT, { fs: dupFs }).length, 1);
+
+  // 60 distinct services in one compose file — capped at 50
+  const lines = ['services:'];
+  for (let i = 0; i < 60; i++) lines.push(`  svc${i}:`, '    image: x');
+  const bigFs = makeFakeFs({ big: { 'docker-compose.yml': lines.join('\n') } });
+  assert.strictEqual(scan(ROOT, { fs: bigFs }).length, 50);
+});
+
+test('bounds the walk with a hard directory budget', () => {
+  const tree = {};
+  for (let i = 0; i < 2100; i++) tree[`dir${String(i).padStart(4, '0')}`] = {};
+  tree['zz-last'] = { 'package.json': pkg({ name: 'late', scripts: { dev: 'x' } }) };
+  const base = makeFakeFs(tree);
+  let readdirCalls = 0;
+  const fs = {
+    ...base,
+    readdirSync: (...args) => { readdirCalls++; return base.readdirSync(...args); },
+  };
+  const result = scan(ROOT, { fs });
+  assert.ok(readdirCalls <= 2000, `visited ${readdirCalls} dirs, expected <= 2000`);
+  assert.deepStrictEqual(result, []); // budget exhausted before the last dir
+});
+
+test('escapes regex metacharacters in compose service patterns', () => {
+  const fs = makeFakeFs({
+    x: { 'docker-compose.yml': 'services:\n  my.svc:\n    image: x\n' },
+  });
+  const [s] = scan(ROOT, { fs });
+  assert.strictEqual(s.pattern, 'my\\.svc');
+  assert.doesNotThrow(() => new RegExp(s.pattern, 'i'));
+});


### PR DESCRIPTION
## Summary
- New `main/services/profile-scanner.js` (Electron-free, injectable `fs`): walks a chosen folder at depth <= 2 — skipping `node_modules`, dot-directories and common junk dirs — and suggests service profiles from `package.json` scripts (`npm run dev` / `npm start`, pattern `node`) and `docker-compose.yml`/`docker-compose.yaml`/`compose.yaml` top-level services (`docker compose up <svc>`, pattern = escaped service name). Regex-based compose parsing keeps it dependency-free; results are deduped, capped at 50 suggestions, and the walk is bounded by a 2000-directory budget. Broken/unreadable files are skipped silently.
- `scan-profile-suggestions` IPC handler (openDirectory dialog, mirroring export-snapshot conventions) + `scanProfileSuggestions()` preload method, both at the designated anchors.
- Settings > Profiles gains an "Import suggestions…" button that shows a checkbox panel; confirmed selections are appended as a new profile through the existing `updateSetting('profiles', ...)` path so config validation and `config-changed` fire as usual. Batch ids are deterministic (timestamp + index) to avoid same-millisecond collisions, and the pending panel state is cleared when the modal closes.
- CSS appended at the end of `components.css` under its own banner.

## Testing
- `npm test`: 45 tests pass, including 14 new fake-fs tests (dev/start detection, compose extraction with comments and deeper indentation, skip rules, depth limit, broken JSON, dedupe + cap, walk budget, regex escaping).
- `npm run lint`: clean.
- Smoke boot: `electron .` ran 15 s with no uncaught exceptions or renderer errors; process tree killed by PID afterwards.
