### PR TITLE
Show which project owns each listening port

### DIFF
--- a/main/poll-manager.js
+++ b/main/poll-manager.js
@@ -7,6 +7,7 @@ const { detect, detectThresholds, detectDuplicates } = require('./services/anoma
 const config = require('./services/config');
 const cpuAccumulator = require('./services/cpu-accumulator');
 const healthCollector = require('./collectors/health-collector');
+const projectResolver = require('./services/project-resolver');
 
 let busy = false;
 let lastSnapshot = null;
@@ -106,6 +107,12 @@ async function collectAll() {
         if (hasAny) proc.portHealth = portHealth;
       }
     }
+    // Project linkage: attach proc.projectName (from the owning process's
+    // working directory: package.json name or compose dir) for processes
+    // that hold listening ports. Mutates procs in place. Non-blocking:
+    // cached names apply immediately, uncached pids resolve in a background
+    // batch and show up on the next poll — the snapshot never waits on it.
+    await projectResolver.resolve(merged);
 
     // Detect anomalies (port conflicts + resource thresholds)
     const warnings = detect(merged);
@@ -121,6 +128,16 @@ async function collectAll() {
     warnings.push(...duplicateWarnings);
 
     // [anchor: extra-warnings] — additional warning producers go below this line
+
+    // Project linkage: annotate port-related warnings with the owning
+    // project name resolved by the enricher above. `!w.port` also skips
+    // warnings that carry the port:0 sentinel (thresholds, duplicates).
+    for (const w of warnings) {
+      if (!w.port) continue;
+      const wPids = Array.isArray(w.pids) ? w.pids : [w.pid];
+      const owner = merged.find((p) => p.projectName && wPids.includes(p.pid));
+      if (owner) w.message += ` (project: ${owner.projectName})`;
+    }
 
     // A warning can cover one pid (w.pid) or many (w.pids, e.g. duplicates).
     const warningPids = new Set();

--- a/main/services/project-resolver.js
+++ b/main/services/project-resolver.js
@@ -1,0 +1,369 @@
+// Resolves which project owns a listening port by inspecting the owning
+// process's working directory and walking up the tree looking for a
+// package.json (name field) or a docker-compose file (directory name).
+//
+// Platform notes:
+// - linux/darwin: one batched `lsof -a -p <pid,pid,...> -d cwd -Fn` call
+//   gives the true cwd for every pending pid in a single spawn.
+// - win32: the true cwd of another process is not cheaply available, so this
+//   is BEST-EFFORT: one batched Get-CimInstance query returns CommandLine /
+//   ExecutablePath for all pending pids, and we take the directory of the
+//   last script-looking argument (preferred) or the exe path. For
+//   `node server.js`-style processes the script path usually lives inside
+//   the project, which is what we want. Exe paths under system install
+//   locations (Program Files, Windows, ProgramData) are ignored — they never
+//   identify a project.
+//
+// Resolution is taken OFF the poll hot path: resolve() applies already
+// cached names synchronously and schedules the (single-spawn) lookup for
+// uncached pids in the background, so the snapshot never waits on the
+// resolver; names appear on the next poll. Results are cached by pid+name
+// (a process's project cannot change during its lifetime; including the
+// name catches most pid-reuse cases, though a recycled pid with the same
+// image name could in theory inherit a stale label). Dead pids are pruned
+// on every resolve() call. All command execution is wrapped in try/catch —
+// resolution failures never fail a poll.
+
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const path = require('path');
+const defaultFs = require('fs');
+
+const execFileAsync = promisify(execFile);
+
+// Maximum number of directories inspected while walking up from the cwd.
+const MAX_WALK_LEVELS = 6;
+// Above this many pending pids, query Win32_Process unfiltered instead of
+// building an enormous WQL OR-filter.
+const MAX_WQL_FILTER_PIDS = 50;
+
+const COMPOSE_FILES = [
+  'docker-compose.yml',
+  'docker-compose.yaml',
+  'compose.yaml',
+  'compose.yml',
+];
+
+// PowerShell cold start can be slow; match detail-collector's conventions.
+const PS_EXEC_OPTS = {
+  encoding: 'utf-8',
+  timeout: 10000,
+  windowsHide: true,
+  maxBuffer: 10 * 1024 * 1024,
+};
+
+// cache key (`pid:name`) -> project name string, or null when resolution
+// ran but found nothing.
+const cache = new Map();
+// Keys currently being resolved in the background (avoid duplicate spawns).
+const inFlight = new Set();
+// Chain of scheduled background lookups; awaited by flushPending() in tests.
+let pendingChain = Promise.resolve();
+
+function cacheKey(proc) {
+  return `${proc.pid}:${proc.name || ''}`;
+}
+
+// ── Pure helpers (exported for tests) ──────────────────────────
+
+/**
+ * Parse `lsof -a -p <pid,...> -d cwd -Fn` output into a Map of pid -> cwd.
+ * Each process block starts with a `p<pid>` line; the cwd shows up as a
+ * line prefixed with `n`, e.g. `n/home/lucas/code/my-shop`.
+ */
+function parseLsofCwd(output) {
+  const map = new Map();
+  let currentPid = null;
+  for (const raw of String(output || '').split('\n')) {
+    const line = raw.replace(/\r$/, '');
+    if (!line) continue;
+    if (line.startsWith('p')) {
+      const pid = parseInt(line.slice(1), 10);
+      currentPid = Number.isNaN(pid) ? null : pid;
+    } else if (line.startsWith('n') && line.length > 1 && currentPid !== null) {
+      if (!map.has(currentPid)) map.set(currentPid, line.slice(1));
+    }
+  }
+  return map;
+}
+
+/**
+ * Parse `Get-CimInstance ... | Select-Object ProcessId,CommandLine,
+ * ExecutablePath | ConvertTo-Json -Compress` output into a Map of
+ * pid -> { commandLine, executablePath }. ConvertTo-Json emits a bare
+ * object for a single match and an array otherwise.
+ */
+function parseCimProcesses(output) {
+  const map = new Map();
+  const trimmed = String(output || '').trim();
+  if (!trimmed) return map;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return map;
+  }
+
+  const items = Array.isArray(parsed) ? parsed : [parsed];
+  for (const item of items) {
+    if (!item) continue;
+    const pid = Number(item.ProcessId);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    map.set(pid, {
+      commandLine: item.CommandLine || null,
+      executablePath: item.ExecutablePath || null,
+    });
+  }
+  return map;
+}
+
+/** Split a command line into tokens, honouring double quotes. */
+function tokenizeCommandLine(commandLine) {
+  const tokens = [];
+  const re = /"([^"]*)"|(\S+)/g;
+  let m;
+  while ((m = re.exec(commandLine)) !== null) {
+    tokens.push(m[1] !== undefined ? m[1] : m[2]);
+  }
+  return tokens;
+}
+
+/**
+ * True for directories under system install locations that never identify
+ * a project (node.exe lives in Program Files, etc.).
+ */
+function isSystemInstallDir(dir) {
+  return /(^|[\\/])(program files( \(x86\))?|windows|programdata)([\\/]|$)/i.test(dir);
+}
+
+/**
+ * Best-effort directory extraction from a Windows command line. Prefers the
+ * LAST script-looking argument — earlier ones are usually hooks/preloads
+ * (`node --require C:\hooks\pre.js C:\proj\server.js`) — over the exe path
+ * (node.exe etc. usually lives outside the project). Directories under
+ * system install locations are never returned.
+ */
+function parseCommandLineDir(commandLine) {
+  if (!commandLine || typeof commandLine !== 'string') return null;
+  const tokens = tokenizeCommandLine(commandLine);
+  if (tokens.length === 0) return null;
+
+  const scriptExt = /\.(js|mjs|cjs|ts|jsx|tsx|py|rb|php)$/i;
+  for (let i = tokens.length - 1; i >= 1; i--) {
+    const token = tokens[i];
+    if (scriptExt.test(token) && /[\\/]/.test(token)) {
+      const dir = path.win32.dirname(token);
+      if (!isSystemInstallDir(dir)) return dir;
+    }
+  }
+
+  if (/[\\/]/.test(tokens[0])) {
+    const dir = path.win32.dirname(tokens[0]);
+    if (!isSystemInstallDir(dir)) return dir;
+  }
+  return null;
+}
+
+/** Directory for one Win32_Process record, or null. */
+function dirFromWinProcessInfo(info) {
+  if (!info) return null;
+  const fromCommandLine = parseCommandLineDir(info.commandLine);
+  if (fromCommandLine) return fromCommandLine;
+  // CommandLine is null for elevated processes; fall back to the exe path
+  // (parseCommandLineDir applies the system-dir blocklist).
+  return parseCommandLineDir(info.executablePath ? `"${info.executablePath}"` : null);
+}
+
+/** True when dir is (or is inside) a node_modules tree. */
+function isInsideNodeModules(dir) {
+  return /(^|[\\/])node_modules([\\/]|$)/i.test(dir);
+}
+
+/**
+ * Walk up from startDir looking for a project marker:
+ * - package.json with a `name` field → that name
+ * - docker-compose.yml / compose.yaml (and .yml/.yaml variants) → dir name
+ * Directories inside node_modules are skipped (a dependency's package.json
+ * is not the project) but the walk continues above them. Stops at the
+ * filesystem/drive root or after MAX_WALK_LEVELS directories.
+ * `fs` is injectable for tests.
+ */
+function findProjectName(startDir, { fs = defaultFs } = {}) {
+  if (!startDir || typeof startDir !== 'string') return null;
+
+  let dir = startDir;
+  for (let level = 0; level < MAX_WALK_LEVELS; level++) {
+    if (!isInsideNodeModules(dir)) {
+      try {
+        const pkgPath = path.join(dir, 'package.json');
+        if (fs.existsSync(pkgPath)) {
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+          if (pkg && typeof pkg.name === 'string' && pkg.name.trim()) {
+            return pkg.name.trim();
+          }
+        }
+      } catch {
+        // Unreadable/broken package.json — fall through to compose, keep walking.
+      }
+
+      try {
+        for (const composeFile of COMPOSE_FILES) {
+          if (fs.existsSync(path.join(dir, composeFile))) {
+            const base = path.basename(dir);
+            if (base) return base;
+          }
+        }
+      } catch {
+        // Ignore fs errors and keep walking.
+      }
+    }
+
+    const parent = path.dirname(dir);
+    if (!parent || parent === dir) break; // filesystem / drive root
+    dir = parent;
+  }
+  return null;
+}
+
+// ── Batched process-directory lookup (one spawn per batch) ─────
+
+async function getProcessDirs(pids) {
+  const valid = [...new Set(pids)].filter((p) => Number.isInteger(p) && p > 0);
+  if (valid.length === 0) return new Map();
+
+  try {
+    if (process.platform === 'win32') {
+      // One PowerShell spawn for the whole batch.
+      const filter = valid.length <= MAX_WQL_FILTER_PIDS
+        ? ` -Filter "${valid.map((p) => `ProcessId=${p}`).join(' OR ')}"`
+        : '';
+      const { stdout } = await execFileAsync('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Get-CimInstance Win32_Process${filter} | ` +
+          'Select-Object ProcessId,CommandLine,ExecutablePath | ConvertTo-Json -Compress',
+      ], PS_EXEC_OPTS);
+
+      const wanted = new Set(valid);
+      const dirs = new Map();
+      for (const [pid, info] of parseCimProcesses(stdout)) {
+        if (!wanted.has(pid)) continue;
+        const dir = dirFromWinProcessInfo(info);
+        if (dir) dirs.set(pid, dir);
+      }
+      return dirs;
+    }
+
+    // linux / darwin: lsof gives the real cwd; one spawn for all pids.
+    // lsof exits non-zero when any pid in the list is gone but still prints
+    // output for the live ones, so keep stdout from the error object too.
+    let stdout = '';
+    try {
+      ({ stdout } = await execFileAsync('lsof', [
+        '-a', '-p', valid.join(','), '-d', 'cwd', '-Fn',
+      ], { encoding: 'utf-8', timeout: 10000, maxBuffer: 10 * 1024 * 1024 }));
+    } catch (err) {
+      stdout = (err && err.stdout) || '';
+    }
+    return parseLsofCwd(stdout);
+  } catch {
+    return new Map();
+  }
+}
+
+// ── Resolution driver ──────────────────────────────────────────
+
+/** True when the process holds at least one LISTENING port. */
+function ownsListeningPort(proc) {
+  const details = proc.portDetails;
+  if (Array.isArray(details) && details.length > 0) {
+    return details.some((d) => !d.state || d.state === 'LISTENING' || d.state === 'LISTEN');
+  }
+  return Array.isArray(proc.ports) && proc.ports.length > 0;
+}
+
+async function resolveBatch(entries, { getDirsForPids, fs }) {
+  try {
+    const dirs = await getDirsForPids(entries.map((e) => e.pid));
+    for (const entry of entries) {
+      let name = null;
+      try {
+        const dir = dirs && dirs.get(entry.pid);
+        if (dir) name = findProjectName(dir, { fs });
+      } catch {
+        name = null;
+      }
+      cache.set(entry.key, name);
+    }
+  } catch {
+    // Leave the keys uncached; they will be retried on a later poll.
+  } finally {
+    for (const entry of entries) inFlight.delete(entry.key);
+  }
+}
+
+/**
+ * Attach `proc.projectName` to processes that own listening ports.
+ * Mutates the given array's entries in place and never blocks the poll:
+ * cached names are applied synchronously, uncached pids are looked up by a
+ * single batched command scheduled in the background (names show up on the
+ * next poll). Dead pids are pruned from the cache. Options are injectable
+ * for tests: { getDirsForPids, fs }.
+ */
+async function resolve(processes, { getDirsForPids = getProcessDirs, fs = defaultFs } = {}) {
+  try {
+    if (!Array.isArray(processes)) return processes;
+
+    const aliveKeys = new Set();
+    const pending = [];
+
+    for (const proc of processes) {
+      const key = cacheKey(proc);
+      aliveKeys.add(key);
+      if (!ownsListeningPort(proc)) continue;
+
+      if (cache.has(key)) {
+        const cached = cache.get(key);
+        if (cached) proc.projectName = cached;
+      } else if (!inFlight.has(key)) {
+        inFlight.add(key);
+        pending.push({ key, pid: proc.pid });
+      }
+    }
+
+    // Prune cache entries for processes that no longer exist.
+    for (const key of cache.keys()) {
+      if (!aliveKeys.has(key)) cache.delete(key);
+    }
+
+    if (pending.length > 0) {
+      const job = resolveBatch(pending, { getDirsForPids, fs });
+      pendingChain = pendingChain.then(() => job);
+    }
+  } catch {
+    // Never fail the poll because of project resolution.
+  }
+  return processes;
+}
+
+/** Await all background lookups scheduled so far (test helper). */
+function flushPending() {
+  return pendingChain;
+}
+
+module.exports = {
+  resolve,
+  flushPending,
+  findProjectName,
+  parseLsofCwd,
+  parseCimProcesses,
+  parseCommandLineDir,
+  dirFromWinProcessInfo,
+  tokenizeCommandLine,
+  isSystemInstallDir,
+  isInsideNodeModules,
+  ownsListeningPort,
+  cache,
+};

--- a/renderer/js/components/process-table.js
+++ b/renderer/js/components/process-table.js
@@ -153,7 +153,7 @@ function buildProcessThead() {
 }
 
 // ── Port cell ──────────────────────────────────────────────────
-function renderPortCell(ports, portHealth) {
+function renderPortCell(ports, portHealth, projectName) {
   if (!ports || ports.length === 0) return h('span', {}, '—');
 
   const container = h('span', { className: 'port-cell' });
@@ -182,6 +182,10 @@ function renderPortCell(ports, portHealth) {
   });
   if (ports.length > 2) {
     container.appendChild(h('span', { className: 'port-more' }, ` +${ports.length - 2}`));
+  }
+  // Project label sits after (outside) the .port-link elements.
+  if (projectName) {
+    container.appendChild(h('span', { className: 'port-project', title: `Project: ${projectName}` }, projectName));
   }
   return container;
 }
@@ -237,7 +241,7 @@ function populateRow(tr, proc, opts = {}) {
 
   tr.appendChild(h('td', { className: 'col-name', title: proc.name }, nameChildren));
   tr.appendChild(h('td', { className: 'col-pid' }, proc.pid.toString()));
-  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(proc.ports, proc.portHealth)]));
+  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(proc.ports, proc.portHealth, proc.projectName)]));
   tr.appendChild(cpuCell);
   tr.appendChild(ramCell);
   tr.appendChild(h('td', { className: 'col-uptime' }, formatUptime(proc.started)));
@@ -266,6 +270,7 @@ function clusterAggregate(procs) {
   let oldest = Infinity;
   const portSet = new Set();
   const portHealth = {};
+  const projectSet = new Set();
   let anyWarning = false;
 
   for (const p of procs) {
@@ -274,6 +279,7 @@ function clusterAggregate(procs) {
     if (p.started && p.started < oldest) oldest = p.started;
     if (p.ports) for (const port of p.ports) portSet.add(port);
     if (p.portHealth) Object.assign(portHealth, p.portHealth);
+    if (p.projectName) projectSet.add(p.projectName);
     if (p.hasWarning) anyWarning = true;
   }
 
@@ -283,6 +289,8 @@ function clusterAggregate(procs) {
     oldest: oldest === Infinity ? null : oldest,
     ports: Array.from(portSet).sort((a, b) => a - b),
     portHealth,
+    // Only label the cluster when its members agree on a single project.
+    projectName: projectSet.size === 1 ? projectSet.values().next().value : null,
     anyWarning,
   };
 }
@@ -327,7 +335,7 @@ function populateClusterRow(tr, cluster) {
 
   tr.appendChild(nameCell);
   tr.appendChild(h('td', { className: 'col-pid cluster-pid' }, `${procs.length} pids`));
-  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(agg.ports, agg.portHealth)]));
+  tr.appendChild(h('td', { className: 'col-port' }, [renderPortCell(agg.ports, agg.portHealth, agg.projectName)]));
   tr.appendChild(cpuCell);
   tr.appendChild(ramCell);
   tr.appendChild(h('td', { className: 'col-uptime' }, formatUptime(agg.oldest)));

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -1718,4 +1718,18 @@
   text-align: center;
   color: var(--text-secondary);
   font-size: 13px;
+/* ── Port project labels ─────────── */
+.port-project {
+  margin-left: 6px;
+  font-size: 10px;
+  font-variant: small-caps;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  opacity: 0.8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 90px;
+  display: inline-block;
+  vertical-align: bottom;
 }

--- a/test/project-resolver.test.js
+++ b/test/project-resolver.test.js
@@ -1,0 +1,383 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const {
+  resolve,
+  flushPending,
+  findProjectName,
+  parseLsofCwd,
+  parseCimProcesses,
+  parseCommandLineDir,
+  dirFromWinProcessInfo,
+  cache,
+} = require('../main/services/project-resolver');
+
+// ── Fake fs helper ─────────────────────────────────────────────
+// Maps normalized (forward-slash) absolute paths to file contents.
+// Separators are normalized so tests pass regardless of host platform
+// (path.join produces backslashes on Windows).
+function makeFakeFs(files) {
+  const normalize = (p) => String(p).replace(/\\/g, '/');
+  const store = new Map(Object.entries(files).map(([k, v]) => [normalize(k), v]));
+  return {
+    existsSync: (p) => store.has(normalize(p)),
+    readFileSync: (p) => {
+      const key = normalize(p);
+      if (!store.has(key)) {
+        throw new Error(`ENOENT: ${p}`);
+      }
+      return store.get(key);
+    },
+  };
+}
+
+beforeEach(() => {
+  cache.clear();
+});
+
+// ── findProjectName ────────────────────────────────────────────
+
+test('findProjectName finds package.json name in the start directory', () => {
+  const fs = makeFakeFs({
+    '/home/lucas/code/my-shop/package.json': JSON.stringify({ name: 'my-shop' }),
+  });
+  assert.strictEqual(findProjectName('/home/lucas/code/my-shop', { fs }), 'my-shop');
+});
+
+test('findProjectName walks up to a parent package.json', () => {
+  const fs = makeFakeFs({
+    '/home/lucas/code/my-shop/package.json': JSON.stringify({ name: 'my-shop' }),
+  });
+  assert.strictEqual(
+    findProjectName('/home/lucas/code/my-shop/src/server', { fs }),
+    'my-shop'
+  );
+});
+
+test('findProjectName falls back to compose file directory name', () => {
+  const fs = makeFakeFs({
+    '/srv/apps/blog-stack/docker-compose.yml': 'services: {}',
+  });
+  assert.strictEqual(findProjectName('/srv/apps/blog-stack/api', { fs }), 'blog-stack');
+});
+
+test('findProjectName supports compose.yaml variant', () => {
+  const fs = makeFakeFs({
+    '/srv/apps/blog-stack/compose.yaml': 'services: {}',
+  });
+  assert.strictEqual(findProjectName('/srv/apps/blog-stack', { fs }), 'blog-stack');
+});
+
+test('findProjectName prefers package.json name over compose in same dir', () => {
+  const fs = makeFakeFs({
+    '/x/app/package.json': JSON.stringify({ name: 'pkg-name' }),
+    '/x/app/docker-compose.yml': 'services: {}',
+  });
+  assert.strictEqual(findProjectName('/x/app', { fs }), 'pkg-name');
+});
+
+test('findProjectName returns null when nothing found up to the root', () => {
+  const fs = makeFakeFs({});
+  assert.strictEqual(findProjectName('/a/b/c', { fs }), null);
+});
+
+test('findProjectName stops after ~6 levels', () => {
+  // Marker is 7 directories above the start dir — beyond the walk limit.
+  const fs = makeFakeFs({
+    '/package.json': JSON.stringify({ name: 'too-far' }),
+  });
+  assert.strictEqual(findProjectName('/a/b/c/d/e/f/g', { fs }), null);
+});
+
+test('findProjectName handles broken package.json by continuing the walk', () => {
+  const fs = makeFakeFs({
+    '/home/app/sub/package.json': '{ not valid json !!',
+    '/home/app/package.json': JSON.stringify({ name: 'real-app' }),
+  });
+  assert.strictEqual(findProjectName('/home/app/sub', { fs }), 'real-app');
+});
+
+test('findProjectName ignores package.json without a name field', () => {
+  const fs = makeFakeFs({
+    '/home/app/sub/package.json': JSON.stringify({ private: true }),
+    '/home/app/docker-compose.yml': 'services: {}',
+  });
+  assert.strictEqual(findProjectName('/home/app/sub', { fs }), 'app');
+});
+
+test('findProjectName skips package.json inside node_modules and keeps walking', () => {
+  const fs = makeFakeFs({
+    '/home/app/node_modules/some-tool/package.json': JSON.stringify({ name: 'some-tool' }),
+    '/home/app/package.json': JSON.stringify({ name: 'real-app' }),
+  });
+  assert.strictEqual(
+    findProjectName('/home/app/node_modules/some-tool', { fs }),
+    'real-app'
+  );
+});
+
+test('findProjectName handles missing/invalid start dir', () => {
+  const fs = makeFakeFs({});
+  assert.strictEqual(findProjectName(null, { fs }), null);
+  assert.strictEqual(findProjectName('', { fs }), null);
+  assert.strictEqual(findProjectName(undefined, { fs }), null);
+});
+
+// ── parseLsofCwd (batched) ─────────────────────────────────────
+
+test('parseLsofCwd maps pids to their n-prefixed cwd lines', () => {
+  const output = [
+    'p1234',
+    'fcwd',
+    'n/home/lucas/code/my-shop',
+    'p5678',
+    'fcwd',
+    'n/srv/apps/blog',
+  ].join('\n');
+  const map = parseLsofCwd(output);
+  assert.strictEqual(map.get(1234), '/home/lucas/code/my-shop');
+  assert.strictEqual(map.get(5678), '/srv/apps/blog');
+  assert.strictEqual(map.size, 2);
+});
+
+test('parseLsofCwd handles CRLF, missing n lines, and empty input', () => {
+  const crlf = parseLsofCwd('p1234\r\nfcwd\r\nn/srv/app\r\n');
+  assert.strictEqual(crlf.get(1234), '/srv/app');
+
+  assert.strictEqual(parseLsofCwd('p1234\nfcwd\n').size, 0);
+  assert.strictEqual(parseLsofCwd('').size, 0);
+  assert.strictEqual(parseLsofCwd(null).size, 0);
+});
+
+// ── parseCimProcesses (win32 batched JSON) ─────────────────────
+
+test('parseCimProcesses parses an array of process records', () => {
+  const output = JSON.stringify([
+    { ProcessId: 100, CommandLine: 'node C:\\proj\\server.js', ExecutablePath: 'C:\\Program Files\\nodejs\\node.exe' },
+    { ProcessId: 200, CommandLine: null, ExecutablePath: 'C:\\tools\\app\\app.exe' },
+  ]);
+  const map = parseCimProcesses(output);
+  assert.strictEqual(map.get(100).commandLine, 'node C:\\proj\\server.js');
+  assert.strictEqual(map.get(200).commandLine, null);
+  assert.strictEqual(map.get(200).executablePath, 'C:\\tools\\app\\app.exe');
+});
+
+test('parseCimProcesses handles a bare single object and garbage input', () => {
+  const single = parseCimProcesses(JSON.stringify(
+    { ProcessId: 42, CommandLine: 'x', ExecutablePath: null }
+  ));
+  assert.strictEqual(single.get(42).commandLine, 'x');
+
+  assert.strictEqual(parseCimProcesses('not json').size, 0);
+  assert.strictEqual(parseCimProcesses('').size, 0);
+  assert.strictEqual(parseCimProcesses(null).size, 0);
+});
+
+// ── parseCommandLineDir (win32 best-effort) ────────────────────
+
+test('parseCommandLineDir prefers the script path over the exe path', () => {
+  const dir = parseCommandLineDir(
+    '"C:\\Program Files\\nodejs\\node.exe" C:\\code\\my-shop\\server.js --port 3000'
+  );
+  assert.strictEqual(dir, 'C:\\code\\my-shop');
+});
+
+test('parseCommandLineDir picks the LAST script-looking argument', () => {
+  const dir = parseCommandLineDir(
+    '"C:\\Program Files\\nodejs\\node.exe" --require C:\\hooks\\preload.js C:\\proj\\server.js'
+  );
+  assert.strictEqual(dir, 'C:\\proj');
+});
+
+test('parseCommandLineDir handles quoted script paths with spaces', () => {
+  const dir = parseCommandLineDir(
+    '"C:\\Program Files\\nodejs\\node.exe" "C:\\My Projects\\shop\\index.js"'
+  );
+  assert.strictEqual(dir, 'C:\\My Projects\\shop');
+});
+
+test('parseCommandLineDir falls back to the exe directory', () => {
+  const dir = parseCommandLineDir('"C:\\tools\\my-app\\my-app.exe" --serve');
+  assert.strictEqual(dir, 'C:\\tools\\my-app');
+});
+
+test('parseCommandLineDir never returns system install directories', () => {
+  assert.strictEqual(
+    parseCommandLineDir('"C:\\Program Files\\nodejs\\node.exe" --inspect'),
+    null
+  );
+  assert.strictEqual(
+    parseCommandLineDir('C:\\Windows\\System32\\svchost.exe -k netsvcs'),
+    null
+  );
+  assert.strictEqual(
+    parseCommandLineDir('"C:\\Program Files (x86)\\Tool\\tool.exe" run "C:\\Program Files (x86)\\Tool\\lib\\main.js"'),
+    null
+  );
+});
+
+test('parseCommandLineDir returns null for bare commands and empty input', () => {
+  assert.strictEqual(parseCommandLineDir('node'), null);
+  assert.strictEqual(parseCommandLineDir(''), null);
+  assert.strictEqual(parseCommandLineDir(null), null);
+});
+
+test('dirFromWinProcessInfo falls back to executablePath when CommandLine is null', () => {
+  assert.strictEqual(
+    dirFromWinProcessInfo({ commandLine: null, executablePath: 'C:\\tools\\my app\\app.exe' }),
+    'C:\\tools\\my app'
+  );
+  // Exe under Program Files never identifies a project.
+  assert.strictEqual(
+    dirFromWinProcessInfo({ commandLine: null, executablePath: 'C:\\Program Files\\nodejs\\node.exe' }),
+    null
+  );
+  assert.strictEqual(dirFromWinProcessInfo(null), null);
+});
+
+// ── resolve: cache and prune behavior ──────────────────────────
+
+function makeProc(pid, ports = [3000]) {
+  return {
+    pid,
+    name: 'node.exe',
+    ports,
+    portDetails: ports.map((port) => ({
+      protocol: 'TCP', localAddress: '0.0.0.0', port, state: 'LISTENING', pid,
+    })),
+  };
+}
+
+function key(pid) {
+  return `${pid}:node.exe`;
+}
+
+const fakeProjectFs = makeFakeFs({
+  [path.join('/proj/my-shop', 'package.json')]: JSON.stringify({ name: 'my-shop' }),
+});
+
+function makeGetDirs(dirByPid, counter) {
+  return async (pids) => {
+    counter.calls++;
+    counter.pids = pids;
+    const map = new Map();
+    for (const pid of pids) {
+      if (dirByPid[pid]) map.set(pid, dirByPid[pid]);
+    }
+    return map;
+  };
+}
+
+test('resolve fills the cache in the background and applies names on the next poll', async () => {
+  const counter = { calls: 0 };
+  const getDirsForPids = makeGetDirs({ 100: '/proj/my-shop' }, counter);
+  const opts = { getDirsForPids, fs: fakeProjectFs };
+
+  const first = [makeProc(100), { pid: 200, name: 'idle.exe', ports: [], portDetails: [] }];
+  await resolve(first, opts);
+  // Non-blocking: resolve() returns before the lookup completes.
+  await flushPending();
+  assert.strictEqual(cache.get(key(100)), 'my-shop');
+  // Only the listening-port pid was looked up.
+  assert.deepStrictEqual(counter.pids, [100]);
+
+  const second = [makeProc(100)];
+  await resolve(second, opts);
+  assert.strictEqual(second[0].projectName, 'my-shop');
+});
+
+test('resolve looks a pid up at most once (cache hit, single batch call)', async () => {
+  const counter = { calls: 0 };
+  const opts = { getDirsForPids: makeGetDirs({ 100: '/proj/my-shop' }, counter), fs: fakeProjectFs };
+
+  await resolve([makeProc(100)], opts);
+  await flushPending();
+  await resolve([makeProc(100)], opts);
+  await resolve([makeProc(100)], opts);
+  await flushPending();
+
+  assert.strictEqual(counter.calls, 1);
+});
+
+test('resolve does not schedule duplicate lookups while one is in flight', async () => {
+  let calls = 0;
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  const getDirsForPids = async () => {
+    calls++;
+    await gate;
+    return new Map([[100, '/proj/my-shop']]);
+  };
+  const opts = { getDirsForPids, fs: fakeProjectFs };
+
+  await resolve([makeProc(100)], opts); // schedules lookup
+  await resolve([makeProc(100)], opts); // still in flight — no second spawn
+  release();
+  await flushPending();
+
+  assert.strictEqual(calls, 1);
+  assert.strictEqual(cache.get(key(100)), 'my-shop');
+});
+
+test('resolve caches negative results (no re-lookup for unresolvable pids)', async () => {
+  const counter = { calls: 0 };
+  const opts = { getDirsForPids: makeGetDirs({}, counter), fs: fakeProjectFs };
+
+  await resolve([makeProc(100)], opts);
+  await flushPending();
+  const second = [makeProc(100)];
+  await resolve(second, opts);
+  await flushPending();
+
+  assert.strictEqual(counter.calls, 1);
+  assert.strictEqual(cache.get(key(100)), null);
+  assert.strictEqual(second[0].projectName, undefined);
+});
+
+test('resolve prunes cache entries for dead pids', async () => {
+  const counter = { calls: 0 };
+  const opts = {
+    getDirsForPids: makeGetDirs({ 100: '/proj/my-shop', 101: '/proj/my-shop' }, counter),
+    fs: fakeProjectFs,
+  };
+
+  await resolve([makeProc(100), makeProc(101)], opts);
+  await flushPending();
+  assert.strictEqual(cache.size, 2);
+
+  // pid 101 disappeared from the process list.
+  await resolve([makeProc(100)], opts);
+  assert.strictEqual(cache.has(key(100)), true);
+  assert.strictEqual(cache.has(key(101)), false);
+});
+
+test('resolve never throws when the batched lookup fails, and retries later', async () => {
+  let calls = 0;
+  const failing = async () => { calls++; throw new Error('boom'); };
+  const procs = [makeProc(100)];
+
+  await assert.doesNotReject(resolve(procs, { getDirsForPids: failing, fs: fakeProjectFs }));
+  await flushPending();
+  assert.strictEqual(procs[0].projectName, undefined);
+  // A failed batch leaves the pid uncached so a later poll retries it.
+  await resolve([makeProc(100)], { getDirsForPids: failing, fs: fakeProjectFs });
+  await flushPending();
+  assert.strictEqual(calls, 2);
+});
+
+test('resolve skips processes with only non-listening connections', async () => {
+  const counter = { calls: 0 };
+  const opts = { getDirsForPids: makeGetDirs({ 300: '/proj/my-shop' }, counter), fs: fakeProjectFs };
+  const proc = {
+    pid: 300,
+    name: 'chrome.exe',
+    ports: [54321],
+    portDetails: [{ protocol: 'TCP', localAddress: '192.168.1.2', port: 54321, state: 'ESTABLISHED', pid: 300 }],
+  };
+
+  await resolve([proc], opts);
+  await flushPending();
+
+  assert.strictEqual(counter.calls, 0);
+  assert.strictEqual(proc.projectName, undefined);
+});


### PR DESCRIPTION
## Summary
- New `main/services/project-resolver.js`: resolves the project owning a listening port from the owning process's working directory — `lsof -a -p <pids> -d cwd -Fn` (one batched spawn) on linux/darwin, best-effort batched `Get-CimInstance Win32_Process` CommandLine/ExecutablePath on win32 (true cwd is not cheaply available there; documented in the file header).
- Directory walk looks for `package.json` (`name` field) or a docker-compose file (directory name), skips `node_modules` trees, and stops at the drive root or after ~6 levels. Pure parts (`findProjectName`, `parseLsofCwd`, `parseCimProcesses`, `parseCommandLineDir`) are exported for tests.
- Resolution is off the poll hot path: cached names apply synchronously, uncached pids resolve in one background batch and appear on the next poll. Cache is keyed by pid+name and pruned for dead pids; all command execution is try/catch — it never fails a poll.
- `main/poll-manager.js`: one block per anchor — `resolve(merged)` at `[anchor: enrichers]`; port warnings (skipping the `port: 0` sentinel) get a `(project: <name>)` suffix at `[anchor: extra-warnings]`.
- Renderer: `renderPortCell` appends a muted `span.port-project` label after (outside) the `.port-link` elements, for both process rows and cluster rows (clusters only labeled when all members agree on one project). CSS appended at the end of `components.css` under its own banner.
- New `test/project-resolver.test.js` (24 tests): directory walk, lsof/CIM/command-line parsers, cache/prune/in-flight/retry behavior with injected fs and lookup.

## Testing
- `npm test`: 59/59 pass; `npm run lint` clean.
- Smoke boot on Windows: app runs 15 s with no uncaught exceptions or renderer errors.
