### PR TITLE
Log tail for profile-launched services

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const { collectAll, getLastSnapshot } = require('./poll-manager');
 const { kill, killMultiple } = require('./services/process-killer');
-const { launchCommand } = require('./services/profile-runner');
+const { launchCommand, getLogs, makeBufferKey } = require('./services/profile-runner');
 const { collect: collectDetails, getExecutablePath } = require('./collectors/detail-collector');
 const { updateTooltip } = require('./tray-manager');
 const notifier = require('./services/notifier');
@@ -80,7 +80,7 @@ function registerIpcHandlers() {
       return { success: false, error: 'No command configured for service' };
     }
 
-    return launchCommand(service.command, service.cwd);
+    return launchCommand(service.command, service.cwd, makeBufferKey(profileId, serviceId));
   });
 
   // ── Open localhost URL in default browser ────────────────────
@@ -176,6 +176,13 @@ function registerIpcHandlers() {
   ipcMain.handle('docker-restart', (_event, id) => dockerCollector.restartContainer(id));
 
   ipcMain.handle('docker-logs', (_event, id, tail) => dockerCollector.getLogs(id, tail));
+  // ── Profile logs ─────────────────────────────────────────────
+  ipcMain.handle('get-service-logs', (_event, { profileId, serviceId } = {}) => {
+    if (typeof profileId !== 'string' || typeof serviceId !== 'string') {
+      return { success: false, error: 'Invalid profile or service id' };
+    }
+    return { success: true, logs: getLogs(makeBufferKey(profileId, serviceId)) };
+  });
 }
 
 module.exports = { registerIpcHandlers };

--- a/main/preload.js
+++ b/main/preload.js
@@ -33,4 +33,6 @@ contextBridge.exposeInMainWorld('api', {
   dockerStop: (id) => ipcRenderer.invoke('docker-stop', id),
   dockerRestart: (id) => ipcRenderer.invoke('docker-restart', id),
   dockerLogs: (id, tail) => ipcRenderer.invoke('docker-logs', id, tail),
+  // ── Profile logs
+  getServiceLogs: (profileId, serviceId) => ipcRenderer.invoke('get-service-logs', { profileId, serviceId }),
 });

--- a/main/services/profile-runner.js
+++ b/main/services/profile-runner.js
@@ -1,6 +1,71 @@
 const { spawn } = require('child_process');
 
-function launchCommand(command, cwd) {
+// ── Log capture ────────────────────────────────────────────────
+// Ring buffer of output lines per bufferKey (profileId:serviceId).
+// The buffer survives child exit so crash output stays readable;
+// relaunching the same key clears it and starts fresh.
+
+const MAX_LOG_LINES = 500;
+// A partial line is force-flushed once it grows past this, so a
+// stream that never emits newlines cannot grow memory unbounded.
+const MAX_REMAINDER_LENGTH = 4096;
+
+const logBuffers = new Map(); // bufferKey → { cap, lines, remainder }
+
+function makeBufferKey(profileId, serviceId) {
+  return `${profileId}:${serviceId}`;
+}
+
+function createLogBuffer(cap = MAX_LOG_LINES) {
+  return { cap, lines: [], remainder: { out: '', err: '' } };
+}
+
+/**
+ * Append a raw stdio chunk to a log buffer. Splits on newlines
+ * (\r\n, \n, or lone \r so carriage-return progress output becomes
+ * lines instead of accumulating), keeping any trailing partial line
+ * in a per-stream remainder, and trims the buffer to its line cap.
+ * Pure with respect to module state — operates only on the buffer
+ * passed in (exported for tests).
+ */
+function appendChunk(buffer, stream, chunk) {
+  const text = buffer.remainder[stream] + String(chunk);
+  const parts = text.split(/\r\n|\r|\n/);
+  let rest = parts.pop();
+  if (rest.length > MAX_REMAINDER_LENGTH) {
+    parts.push(rest);
+    rest = '';
+  }
+  buffer.remainder[stream] = rest;
+  const ts = Date.now();
+  for (const line of parts) {
+    buffer.lines.push({ ts, stream, line });
+  }
+  if (buffer.lines.length > buffer.cap) {
+    buffer.lines.splice(0, buffer.lines.length - buffer.cap);
+  }
+  return buffer;
+}
+
+/**
+ * Flush any partial line left in the remainder (called when a
+ * stream ends so trailing output without a newline is not lost).
+ */
+function flushRemainder(buffer, stream) {
+  if (buffer.remainder[stream]) {
+    appendChunk(buffer, stream, '\n');
+  }
+  return buffer;
+}
+
+function getLogs(bufferKey) {
+  const buffer = logBuffers.get(bufferKey);
+  return buffer ? buffer.lines : [];
+}
+
+// ── Launching ──────────────────────────────────────────────────
+
+function launchCommand(command, cwd, bufferKey) {
   if (!command || typeof command !== 'string' || !command.trim()) {
     return { success: false, error: 'No command specified' };
   }
@@ -8,11 +73,39 @@ function launchCommand(command, cwd) {
   try {
     const shell = process.platform === 'win32' ? 'cmd' : 'sh';
     const flag  = process.platform === 'win32' ? '/c' : '-c';
+    const capture = typeof bufferKey === 'string' && bufferKey.length > 0;
+    // detached keeps the service alive independently of the dashboard.
+    // Exception: on Windows a DETACHED_PROCESS cmd.exe cannot hand the
+    // pipe handles down to the actual service process (all grandchild
+    // output is silently lost), so detached is skipped for win32 +
+    // capture; plain child processes survive parent exit on Windows.
+    // Note: pipe capture inherently means that once the dashboard
+    // exits, a service's next stdout write hits a broken pipe — an
+    // accepted trade-off of in-memory capture on every platform.
+    const detached = !(capture && process.platform === 'win32');
     const child = spawn(shell, [flag, command.trim()], {
       cwd: (cwd && cwd.trim()) ? cwd.trim() : undefined,
-      detached: true,
-      stdio: 'ignore',
+      detached,
+      windowsHide: true,
+      stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'ignore',
     });
+
+    if (capture) {
+      // Fresh buffer on every (re)launch of the same key.
+      const buffer = createLogBuffer();
+      logBuffers.set(bufferKey, buffer);
+
+      child.stdout.on('data', (chunk) => appendChunk(buffer, 'out', chunk));
+      child.stderr.on('data', (chunk) => appendChunk(buffer, 'err', chunk));
+      child.stdout.on('end', () => flushRemainder(buffer, 'out'));
+      child.stderr.on('end', () => flushRemainder(buffer, 'err'));
+      // Surface async failures in the log pane instead of crashing the
+      // main process (spawn errors and pipe errors arrive async).
+      child.on('error', (err) => appendChunk(buffer, 'err', `[launch error] ${err.message}\n`));
+      child.stdout.on('error', () => {});
+      child.stderr.on('error', () => {});
+    }
+
     child.unref();
     return { success: true };
   } catch (err) {
@@ -20,4 +113,4 @@ function launchCommand(command, cwd) {
   }
 }
 
-module.exports = { launchCommand };
+module.exports = { launchCommand, getLogs, makeBufferKey, appendChunk, flushRemainder, createLogBuffer };

--- a/renderer/js/components/profile-panel.js
+++ b/renderer/js/components/profile-panel.js
@@ -1,5 +1,17 @@
 /* Profile panel – rendered above the process groups */
 
+// Open log panes, keyed 'profileId:serviceId'. Module-level so the
+// open/closed state survives re-renders.
+const openServiceLogs = new Set();
+// Cached <pre> pane elements per open key. Reused across re-renders so
+// pane content persists (no flicker while the async refresh runs).
+const serviceLogPanes = new Map();
+// Active auto-refresh timers, keyed 'profileId:serviceId'. Cleared on
+// every re-render so intervals never leak across renders.
+const serviceLogTimers = new Map();
+// Container from the latest render, so toggle clicks can re-render.
+let currentProfileContainer = null;
+
 function getProfileStatuses(profile) {
   const allProcesses = Object.values(AppState.groups || {}).flatMap((g) => g.processes || []);
   return profile.services.map((service) => {
@@ -33,7 +45,104 @@ function renderProfileBadge(running, total) {
   return h('span', { className: `profile-badge ${mod}` }, `${running}/${total}`);
 }
 
+function clearServiceLogTimers() {
+  for (const timer of serviceLogTimers.values()) clearInterval(timer);
+  serviceLogTimers.clear();
+}
+
+function paneIsAtBottom(pane) {
+  return pane.scrollHeight - pane.scrollTop - pane.clientHeight < 8;
+}
+
+async function refreshServiceLogPane(pane, profileId, serviceId) {
+  let res;
+  try {
+    res = await window.api.getServiceLogs(profileId, serviceId);
+  } catch {
+    return;
+  }
+  // The pane may have been closed or replaced while awaiting.
+  if (!pane.isConnected || !res || !res.success) return;
+
+  const logs = res.logs || [];
+  const last = logs[logs.length - 1];
+  const sig = logs.length + (last ? `:${last.ts}:${last.line}` : '');
+  if (pane.dataset.logSig === sig) return; // nothing new — skip DOM rebuild
+  const firstFill = pane.dataset.logSig === undefined;
+  pane.dataset.logSig = sig;
+
+  const atBottom = paneIsAtBottom(pane);
+  pane.innerHTML = '';
+  if (logs.length === 0) {
+    pane.appendChild(h('span', { className: 'service-log-empty' }, 'No output captured yet.'));
+    return;
+  }
+  for (const entry of logs) {
+    const cls = entry.stream === 'err' ? 'service-log-line service-log-err' : 'service-log-line';
+    pane.appendChild(h('span', { className: cls }, entry.line));
+    pane.appendChild(document.createTextNode('\n'));
+  }
+  // Follow the tail unless the user has scrolled up to read history.
+  if (atBottom || firstFill) pane.scrollTop = pane.scrollHeight;
+}
+
+function renderServiceRow(profile, status) {
+  const service = status.service;
+  const key = `${profile.id}:${service.id}`;
+  const isOpen = openServiceLogs.has(key);
+
+  const chevron = h('button', {
+    className: `service-log-toggle ${isOpen ? 'open' : ''}`,
+    title: isOpen ? 'Hide logs' : 'Show logs',
+    onClick: () => {
+      if (openServiceLogs.has(key)) {
+        openServiceLogs.delete(key);
+        serviceLogPanes.delete(key);
+      } else {
+        openServiceLogs.add(key);
+      }
+      renderProfilePanel(currentProfileContainer);
+    },
+  }, isOpen ? '▾' : '▸');
+
+  const row = h('div', { className: 'profile-service-row' }, [
+    chevron,
+    h('span', { className: `service-status-dot ${status.running ? 'service-running' : 'service-stopped'}` }),
+    h('span', { className: 'profile-service-name' }, service.name || service.id),
+  ]);
+
+  const parts = [row];
+
+  if (isOpen) {
+    let pane = serviceLogPanes.get(key);
+    if (!pane) {
+      pane = h('pre', { className: 'service-log-pane' });
+      serviceLogPanes.set(key, pane);
+    }
+    parts.push(pane);
+    refreshServiceLogPane(pane, profile.id, service.id);
+    const timer = setInterval(() => refreshServiceLogPane(pane, profile.id, service.id), 2000);
+    serviceLogTimers.set(key, timer);
+  }
+
+  return parts;
+}
+
 function renderProfilePanel(container) {
+  if (!container) return;
+  currentProfileContainer = container;
+
+  // Remember scroll position of open panes across the DOM teardown
+  // (detaching an element resets its scroll state).
+  const scrollState = new Map();
+  for (const [key, pane] of serviceLogPanes) {
+    if (pane.isConnected) {
+      scrollState.set(key, { top: pane.scrollTop, atBottom: paneIsAtBottom(pane) });
+    }
+  }
+
+  clearServiceLogTimers();
+
   const profiles = AppState.profiles || [];
   container.innerHTML = '';
   if (profiles.length === 0) return;
@@ -60,14 +169,29 @@ function renderProfilePanel(container) {
       onClick: () => stopProfile(statuses),
     }, '■ Stop');
 
+    const servicesEl = h('div', { className: 'profile-services' },
+      statuses.flatMap((status) => renderServiceRow(profile, status)));
+
     const card = h('div', { className: 'profile-card' }, [
       h('span', { className: 'profile-name' }, profile.name),
       renderProfileBadge(running, total),
       h('div', { className: 'profile-actions' }, [startBtn, stopBtn]),
+      servicesEl,
     ]);
 
     panel.appendChild(card);
   }
 
   container.appendChild(panel);
+
+  // Restore scroll positions now that the panes are re-attached, and
+  // drop cached panes that no longer exist (closed or removed profile).
+  for (const [key, pane] of serviceLogPanes) {
+    if (!pane.isConnected) {
+      serviceLogPanes.delete(key);
+      continue;
+    }
+    const saved = scrollState.get(key);
+    if (saved) pane.scrollTop = saved.atBottom ? pane.scrollHeight : saved.top;
+  }
 }

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -1512,3 +1512,83 @@
   white-space: pre-wrap;
   word-break: break-all;
 }
+/* ── Profile service logs ─────────── */
+
+.profile-card {
+  flex-wrap: wrap;
+}
+
+.profile-services {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.profile-service-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.service-log-toggle {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 1px 3px;
+  line-height: 1;
+}
+
+.service-log-toggle:hover {
+  color: var(--text-primary);
+}
+
+.service-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.service-status-dot.service-running {
+  background: var(--accent-green);
+}
+
+.service-status-dot.service-stopped {
+  background: var(--text-secondary);
+  opacity: 0.5;
+}
+
+.profile-service-name {
+  font-weight: 500;
+}
+
+.service-log-pane {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 2px 0 4px 18px;
+  padding: 6px 8px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.service-log-line.service-log-err {
+  color: var(--text-secondary);
+  opacity: 0.85;
+}
+
+.service-log-empty {
+  color: var(--text-secondary);
+  font-style: italic;
+}

--- a/test/profile-runner.test.js
+++ b/test/profile-runner.test.js
@@ -1,0 +1,159 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  launchCommand,
+  getLogs,
+  makeBufferKey,
+  appendChunk,
+  flushRemainder,
+  createLogBuffer,
+} = require('../main/services/profile-runner');
+
+// Inline `node -e "..."` (and any embedded double quotes) does not survive
+// the spawn → cmd /c round-trip on Windows, so write tiny script files and
+// run them by unquoted path instead (os.tmpdir() contains no spaces on the
+// platforms CI runs on).
+const scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'profile-runner-test-'));
+function makeScript(name, source) {
+  const file = path.join(scriptDir, name);
+  fs.writeFileSync(file, source, 'utf8');
+  return `node ${file}`;
+}
+
+function waitFor(predicate, timeoutMs = 5000, intervalMs = 50) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const timer = setInterval(() => {
+      if (predicate()) {
+        clearInterval(timer);
+        resolve();
+      } else if (Date.now() - start > timeoutMs) {
+        clearInterval(timer);
+        reject(new Error('Timed out waiting for condition'));
+      }
+    }, intervalMs);
+  });
+}
+
+test('launchCommand captures stdout and stderr per bufferKey', async () => {
+  const key = 'test-profile:test-service';
+  const cmd = makeScript('both.js', "console.log('hello-out'); console.error('hello-err');");
+
+  const res = launchCommand(cmd, undefined, key);
+  assert.strictEqual(res.success, true);
+
+  await waitFor(() => getLogs(key).length >= 2);
+
+  const logs = getLogs(key);
+  const outLine = logs.find((l) => l.line === 'hello-out');
+  const errLine = logs.find((l) => l.line === 'hello-err');
+  assert.ok(outLine, 'stdout line captured');
+  assert.strictEqual(outLine.stream, 'out');
+  assert.ok(errLine, 'stderr line captured');
+  assert.strictEqual(errLine.stream, 'err');
+  for (const entry of logs) {
+    assert.strictEqual(typeof entry.ts, 'number');
+  }
+});
+
+test('relaunching the same bufferKey clears previous logs', async () => {
+  const key = 'test-profile:relaunch';
+
+  launchCommand(makeScript('first.js', "console.log('first-run');"), undefined, key);
+  await waitFor(() => getLogs(key).some((l) => l.line === 'first-run'));
+
+  launchCommand(makeScript('second.js', "console.log('second-run');"), undefined, key);
+  await waitFor(() => getLogs(key).some((l) => l.line === 'second-run'));
+
+  const logs = getLogs(key);
+  assert.ok(!logs.some((l) => l.line === 'first-run'), 'old logs cleared on relaunch');
+});
+
+test('getLogs returns empty array for unknown key', () => {
+  assert.deepStrictEqual(getLogs('no:such:key'), []);
+});
+
+test('launchCommand without bufferKey still succeeds', () => {
+  const res = launchCommand(makeScript('noop.js', 'process.exit(0);'));
+  assert.strictEqual(res.success, true);
+});
+
+test('launchCommand rejects empty command', () => {
+  const res = launchCommand('', undefined, 'x:y');
+  assert.strictEqual(res.success, false);
+});
+
+test('appendChunk splits chunks into tagged lines', () => {
+  const buf = createLogBuffer();
+  appendChunk(buf, 'out', 'one\ntwo\n');
+  appendChunk(buf, 'err', 'oops\n');
+
+  assert.strictEqual(buf.lines.length, 3);
+  assert.deepStrictEqual(buf.lines.map((l) => l.line), ['one', 'two', 'oops']);
+  assert.deepStrictEqual(buf.lines.map((l) => l.stream), ['out', 'out', 'err']);
+});
+
+test('appendChunk handles partial lines with a per-stream remainder', () => {
+  const buf = createLogBuffer();
+  appendChunk(buf, 'out', 'par');
+  assert.strictEqual(buf.lines.length, 0, 'partial line not emitted yet');
+  appendChunk(buf, 'err', 'other-stream\n');
+  assert.strictEqual(buf.lines.length, 1, 'err remainder independent of out');
+  appendChunk(buf, 'out', 'tial\nnext');
+  assert.strictEqual(buf.lines.length, 2);
+  assert.strictEqual(buf.lines[1].line, 'partial');
+
+  flushRemainder(buf, 'out');
+  assert.strictEqual(buf.lines.length, 3);
+  assert.strictEqual(buf.lines[2].line, 'next');
+  assert.strictEqual(buf.remainder.out, '');
+});
+
+test('appendChunk handles CRLF line endings', () => {
+  const buf = createLogBuffer();
+  appendChunk(buf, 'out', 'a\r\nb\r\n');
+  assert.deepStrictEqual(buf.lines.map((l) => l.line), ['a', 'b']);
+});
+
+test('appendChunk treats lone carriage returns as line breaks (progress output)', () => {
+  const buf = createLogBuffer();
+  appendChunk(buf, 'out', 'Progress 10%\rProgress 20%\rProgress 30%');
+  assert.deepStrictEqual(buf.lines.map((l) => l.line), ['Progress 10%', 'Progress 20%']);
+  assert.strictEqual(buf.remainder.out, 'Progress 30%');
+});
+
+test('appendChunk force-flushes an oversized partial line instead of growing unbounded', () => {
+  const buf = createLogBuffer();
+  appendChunk(buf, 'out', 'x'.repeat(5000));
+  assert.strictEqual(buf.remainder.out, '', 'oversized remainder flushed');
+  assert.strictEqual(buf.lines.length, 1);
+  assert.strictEqual(buf.lines[0].line.length, 5000);
+});
+
+test('makeBufferKey joins profile and service ids', () => {
+  assert.strictEqual(makeBufferKey('p1', 's1'), 'p1:s1');
+});
+
+test('ring buffer caps at the configured line count, keeping newest', () => {
+  const buf = createLogBuffer(5);
+  for (let i = 0; i < 12; i++) {
+    appendChunk(buf, 'out', `line-${i}\n`);
+  }
+  assert.strictEqual(buf.lines.length, 5);
+  assert.deepStrictEqual(
+    buf.lines.map((l) => l.line),
+    ['line-7', 'line-8', 'line-9', 'line-10', 'line-11']
+  );
+});
+
+test('a single oversized chunk is trimmed to the cap', () => {
+  const buf = createLogBuffer(3);
+  const chunk = Array.from({ length: 10 }, (_, i) => `l${i}`).join('\n') + '\n';
+  appendChunk(buf, 'out', chunk);
+  assert.strictEqual(buf.lines.length, 3);
+  assert.deepStrictEqual(buf.lines.map((l) => l.line), ['l7', 'l8', 'l9']);
+});


### PR DESCRIPTION
## Summary
Services started via profiles ran with `stdio: 'ignore'`, so their output — especially crash output — was unreadable. This PR captures stdout/stderr into a per-service in-memory ring buffer and surfaces it in the UI as an expandable log pane per service row.

### Main process
- `main/services/profile-runner.js`: `launchCommand(command, cwd, bufferKey)` now pipes stdout/stderr into a module-level ring buffer per `profileId:serviceId` key (500 lines, per-stream partial-line remainder, lone-`\r` progress output treated as line breaks, oversized partial lines force-flushed so memory stays bounded). The buffer **survives child exit** so crash output stays readable; relaunching the same key starts fresh. Async spawn/pipe errors are written into the buffer instead of being swallowed. `bufferKey` is optional — no capture when absent (backward compatible).
- `main/ipc-handlers.js`: new `get-service-logs` handler (id-validated; commands still looked up main-side only) + the single-line change passing the buffer key in `launch-service-command`.
- `main/preload.js`: `getServiceLogs(profileId, serviceId)`.

### Windows caveat (verified empirically)
A `DETACHED_PROCESS` cmd.exe cannot hand pipe handles down to its grandchildren — **all** service output is silently lost (cmd's own output arrives, any grandchild's does not). So on win32 the spawn is not detached when capturing; plain child processes survive parent exit on Windows regardless (verified: silent grandchild outlives the parent). Note that pipe-based capture on any platform means a service writing after the dashboard exits hits a broken pipe — an inherent trade-off of the in-memory capture design.

### Renderer
- `renderer/js/components/profile-panel.js`: per-service rows with an expand chevron; open panes fetch logs every 2s. Pane elements are cached across the poll-driven full re-renders (no flicker), DOM rebuilds are skipped when the log signature is unchanged, scroll position is preserved across re-renders, and tail-follow only engages when already scrolled to the bottom. Open-state lives in a module-level Set; intervals are cleared on every re-render (no leaks).
- `renderer/styles/components.css`: appended styles under the `Profile service logs` banner only.

### Tests
- New `test/profile-runner.test.js` (no `electron` import — runs in CI): end-to-end capture through real spawns, relaunch-clears-buffer, ring-buffer cap, CRLF/lone-CR/partial-line handling, remainder cap. 43/43 pass; lint clean; smoke-booted the app for 15s with no uncaught exceptions.
