### PR TITLE
Add process tree view, kill-tree, and orphan detection

### DIFF
--- a/main/collectors/process-collector.js
+++ b/main/collectors/process-collector.js
@@ -36,13 +36,14 @@ function parsePsOutput(output) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('PID')) continue;
 
-    // ps output format: PID  RSS  COMMAND
-    const match = trimmed.match(/^\s*(\d+)\s+(\d+)\s+(.+)$/);
+    // ps output format: PID  PPID  RSS  COMMAND
+    const match = trimmed.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/);
     if (!match) continue;
 
     const pid = parseInt(match[1], 10);
-    const memKB = parseInt(match[2], 10) || 0;
-    const cmdline = match[3].trim();
+    const ppid = parseInt(match[2], 10) || 0;
+    const memKB = parseInt(match[3], 10) || 0;
+    const cmdline = match[4].trim();
 
     if (pid === 0) continue;
 
@@ -50,21 +51,120 @@ function parsePsOutput(output) {
     const cmdPath = cmdline.split(/\s/)[0];
     const name = cmdPath.split('/').pop() || cmdPath;
 
-    processes.push({ pid, name, memKB, status: 'Running' });
+    processes.push({ pid, ppid, name, memKB, status: 'Running' });
   }
 
   return processes;
 }
 
+// Parse `Get-CimInstance Win32_Process | Select ProcessId,ParentProcessId |
+// ConvertTo-Csv -NoTypeInformation` output into a Map of pid -> ppid.
+function parseCimPpidCsv(output) {
+  const ppidByPid = new Map();
+  const lines = output.split('\n');
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // CSV format: "ProcessId","ParentProcessId" (header skipped: not numeric)
+    const match = trimmed.match(/^"?(\d+)"?,"?(\d+)"?$/);
+    if (!match) continue;
+
+    const pid = parseInt(match[1], 10);
+    const ppid = parseInt(match[2], 10);
+    ppidByPid.set(pid, ppid);
+  }
+
+  return ppidByPid;
+}
+
+// Parse `wmic process get ProcessId,ParentProcessId` output into a Map of
+// pid -> ppid. wmic orders columns alphabetically, so the header line is
+// used to figure out which column is which.
+function parseWmicPpidOutput(output) {
+  const ppidByPid = new Map();
+  const lines = output.split('\n').map((l) => l.trim()).filter(Boolean);
+  if (lines.length === 0) return ppidByPid;
+
+  const headerCols = lines[0].split(/\s+/);
+  const pidIdx = headerCols.indexOf('ProcessId');
+  const ppidIdx = headerCols.indexOf('ParentProcessId');
+  if (pidIdx === -1 || ppidIdx === -1) return ppidByPid;
+
+  for (const line of lines.slice(1)) {
+    const cols = line.split(/\s+/);
+    if (cols.length === headerCols.length) {
+      const pid = parseInt(cols[pidIdx], 10);
+      const ppid = parseInt(cols[ppidIdx], 10);
+      if (Number.isNaN(pid)) continue;
+      ppidByPid.set(pid, Number.isNaN(ppid) ? 0 : ppid);
+    } else if (cols.length === 1) {
+      // Row with a blank ParentProcessId — only the ProcessId survives the
+      // whitespace split. Keep the process with "unknown parent" (ppid 0)
+      // rather than dropping it.
+      const pid = parseInt(cols[0], 10);
+      if (!Number.isNaN(pid)) ppidByPid.set(pid, 0);
+    }
+  }
+
+  return ppidByPid;
+}
+
+// Windows: tasklist has no parent-pid column, so fetch pid -> ppid pairs
+// separately. PowerShell/CIM first; wmic as a fallback for older systems
+// (wmic is removed on Win11 24H2 but PowerShell is always present).
+async function collectWindowsPpidMap() {
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell',
+      [
+        '-NoProfile',
+        '-Command',
+        'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId | ConvertTo-Csv -NoTypeInformation',
+      ],
+      { encoding: 'utf-8', timeout: 10000, windowsHide: true }
+    );
+    const map = parseCimPpidCsv(stdout);
+    if (map.size > 0) return map;
+  } catch {
+    // fall through to wmic
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      'wmic',
+      ['process', 'get', 'ProcessId,ParentProcessId'],
+      { encoding: 'utf-8', timeout: 10000, windowsHide: true }
+    );
+    return parseWmicPpidOutput(stdout);
+  } catch {
+    return new Map();
+  }
+}
+
 async function collect() {
   if (process.platform === 'win32') {
+    // Known limitations, accepted for a 3-second polling dashboard:
+    // - tasklist and the CIM query are two separate snapshots taken in
+    //   parallel, so a process that starts/exits between them can briefly
+    //   have a missing (0) or stale ppid for one poll.
+    // - Windows reuses pids aggressively; a ppid can point at an unrelated
+    //   newer process that inherited the dead parent's pid.
     try {
-      const { stdout } = await execFileAsync('tasklist', ['/FO', 'CSV', '/NH'], {
-        encoding: 'utf-8',
-        timeout: 5000,
-        windowsHide: true,
-      });
-      return parseTasklistCSV(stdout);
+      const [{ stdout }, ppidByPid] = await Promise.all([
+        execFileAsync('tasklist', ['/FO', 'CSV', '/NH'], {
+          encoding: 'utf-8',
+          timeout: 5000,
+          windowsHide: true,
+        }),
+        collectWindowsPpidMap(),
+      ]);
+      const processes = parseTasklistCSV(stdout);
+      for (const proc of processes) {
+        proc.ppid = ppidByPid.get(proc.pid) || 0;
+      }
+      return processes;
     } catch {
       return [];
     }
@@ -72,7 +172,7 @@ async function collect() {
 
   // Linux and macOS: use ps
   try {
-    const { stdout } = await execFileAsync('ps', ['-eo', 'pid,rss,comm', '--no-headers'], {
+    const { stdout } = await execFileAsync('ps', ['-eo', 'pid,ppid,rss,comm', '--no-headers'], {
       encoding: 'utf-8',
       timeout: 5000,
     });
@@ -80,7 +180,7 @@ async function collect() {
   } catch {
     // macOS ps doesn't support --no-headers, fall back
     try {
-      const { stdout } = await execFileAsync('ps', ['-eo', 'pid,rss,comm'], {
+      const { stdout } = await execFileAsync('ps', ['-eo', 'pid,ppid,rss,comm'], {
         encoding: 'utf-8',
         timeout: 5000,
       });
@@ -91,4 +191,10 @@ async function collect() {
   }
 }
 
-module.exports = { collect, parseTasklistCSV, parsePsOutput };
+module.exports = {
+  collect,
+  parseTasklistCSV,
+  parsePsOutput,
+  parseCimPpidCsv,
+  parseWmicPpidOutput,
+};

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -10,6 +10,7 @@ const notifier = require('./services/notifier');
 const config = require('./services/config');
 const dockerCollector = require('./collectors/docker-collector');
 const httpApi = require('./services/http-api');
+const { killTree } = require('./services/process-killer');
 
 function registerIpcHandlers() {
   // Initialise notifier from saved config
@@ -264,6 +265,11 @@ function registerIpcHandlers() {
   // polling or consumes new-warning notifications.
   ipcMain.handle('get-last-snapshot', () => {
     return getLastSnapshot();
+  });
+
+  // ── Process tree kill ────────────────────────────────────────
+  ipcMain.handle('kill-process-tree', async (_event, pid) => {
+    return killTree(pid);
   });
 }
 

--- a/main/poll-manager.js
+++ b/main/poll-manager.js
@@ -3,7 +3,7 @@ const portCollector = require('./collectors/port-collector');
 const systemCollector = require('./collectors/system-collector');
 const dockerCollector = require('./collectors/docker-collector');
 const { classify, GROUP_META } = require('./services/classifier');
-const { detect, detectThresholds, detectDuplicates } = require('./services/anomaly-detector');
+const { detect, detectThresholds, detectDuplicates, detectOrphans } = require('./services/anomaly-detector');
 const config = require('./services/config');
 const cpuAccumulator = require('./services/cpu-accumulator');
 const healthCollector = require('./collectors/health-collector');
@@ -74,6 +74,7 @@ async function collectAll() {
 
       merged.push({
         pid: proc.pid,
+        ppid: proc.ppid,
         name: proc.name,
         memKB: proc.memKB,
         cpu: sysInfo ? sysInfo.cpu : 0,
@@ -144,6 +145,15 @@ async function collectAll() {
     }
     // User-defined rules: notify/kill/run a command on sustained metric breaches
     warnings.push(...ruleEngine.evaluate(merged, config.get('userRules'), { kill, launchCommand }));
+    // Orphan detection: dev processes whose parent has disappeared.
+    // Stamp proc.isOrphan (like hasWarning below) so the renderer can badge
+    // rows without re-scanning the warnings list.
+    const orphanWarnings = detectOrphans(merged);
+    warnings.push(...orphanWarnings);
+    const orphanPids = new Set(orphanWarnings.map((w) => w.pid));
+    for (const proc of merged) {
+      proc.isOrphan = orphanPids.has(proc.pid);
+    }
 
     // A warning can cover one pid (w.pid) or many (w.pids, e.g. duplicates).
     const warningPids = new Set();

--- a/main/preload.js
+++ b/main/preload.js
@@ -45,4 +45,5 @@ contextBridge.exposeInMainWorld('api', {
   scanProfileSuggestions: () => ipcRenderer.invoke('scan-profile-suggestions'),
   // ── Mini-HUD
   getLastSnapshot: () => ipcRenderer.invoke('get-last-snapshot'),
+  killProcessTree: (pid) => ipcRenderer.invoke('kill-process-tree', pid),
 });

--- a/main/services/anomaly-detector.js
+++ b/main/services/anomaly-detector.js
@@ -123,4 +123,47 @@ function detectDuplicates(processes, { duplicateThreshold }) {
   return warnings;
 }
 
-module.exports = { detect, detectThresholds, detectDuplicates };
+// Detect orphaned dev processes — a dev server that outlives its
+// terminal/editor/agent is the classic leftover a runaway agent leaves
+// behind. Limited to the `dev` group so system daemons stay quiet.
+//
+// The orphan signal is platform-specific:
+// - win32 never reparents: an orphan keeps its dead parent's stale pid, so
+//   "ppid not present in the current pid set" is the signal.
+// - linux/darwin reparent orphans to pid 1 (init/launchd) immediately, so a
+//   dangling ppid never survives long enough to observe — being adopted by
+//   pid 1 IS the signal there (dev processes are normally children of a
+//   shell/editor/agent, not of init).
+//
+// `platform` is injectable for tests; defaults to the current platform.
+function detectOrphans(processes, platform = process.platform) {
+  const warnings = [];
+  const pidSet = new Set();
+  for (const proc of processes) pidSet.add(proc.pid);
+
+  for (const proc of processes) {
+    if (proc.group !== 'dev') continue;
+    // ppid 0/undefined means "unknown", not "orphaned"
+    if (!proc.ppid) continue;
+
+    const orphaned = platform === 'win32'
+      ? !pidSet.has(proc.ppid)
+      : proc.ppid === 1 || !pidSet.has(proc.ppid);
+    if (!orphaned) continue;
+
+    const reason = platform === 'win32'
+      ? `its parent process (PID ${proc.ppid}) is gone`
+      : 'its original parent exited and it was adopted by init';
+    warnings.push({
+      pid: proc.pid,
+      port: 0,
+      processName: proc.name,
+      key: `orphan:${proc.pid}`,
+      message: `${proc.name} (PID ${proc.pid}) is orphaned — ${reason}`,
+    });
+  }
+
+  return warnings;
+}
+
+module.exports = { detect, detectThresholds, detectDuplicates, detectOrphans };

--- a/main/services/process-killer.js
+++ b/main/services/process-killer.js
@@ -1,5 +1,18 @@
 const { execSync } = require('child_process');
 
+// Map a taskkill/kill failure to a user-friendly message. Shared by kill()
+// and killTree() so their error classification never drifts apart.
+function classifyKillError(err) {
+  const msg = err.stderr || err.message || 'Unknown error';
+  if (/access.denied|permission denied|operation not permitted/i.test(msg)) {
+    return 'Access denied — try running with elevated privileges';
+  }
+  if (/not found|no such process/i.test(msg)) {
+    return 'Process no longer exists';
+  }
+  return msg.trim();
+}
+
 function kill(pid) {
   if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) {
     return { success: false, error: 'Invalid PID' };
@@ -20,14 +33,7 @@ function kill(pid) {
     }
     return { success: true };
   } catch (err) {
-    const msg = err.stderr || err.message || 'Unknown error';
-    if (/access.denied|permission denied|operation not permitted/i.test(msg)) {
-      return { success: false, error: 'Access denied — try running with elevated privileges' };
-    }
-    if (/not found|no such process/i.test(msg)) {
-      return { success: false, error: 'Process no longer exists' };
-    }
-    return { success: false, error: msg.trim() };
+    return { success: false, error: classifyKillError(err) };
   }
 }
 
@@ -51,4 +57,105 @@ function killMultiple(pids) {
   };
 }
 
-module.exports = { kill, killMultiple };
+// Parse `ps -eo pid,ppid` output into a Map of ppid -> [child pids].
+function buildChildMap(psOutput) {
+  const childrenOf = new Map();
+  for (const line of psOutput.split('\n')) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)$/);
+    if (!match) continue;
+    const pid = parseInt(match[1], 10);
+    const ppid = parseInt(match[2], 10);
+    if (!childrenOf.has(ppid)) childrenOf.set(ppid, []);
+    childrenOf.get(ppid).push(pid);
+  }
+  return childrenOf;
+}
+
+// Collect all descendants of `pid` breadth-first (parents before children).
+function collectDescendants(pid, childrenOf) {
+  const descendants = [];
+  const seen = new Set([pid]);
+  const queue = [pid];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    for (const child of childrenOf.get(current) || []) {
+      if (seen.has(child)) continue; // guard against pid cycles
+      seen.add(child);
+      descendants.push(child);
+      queue.push(child);
+    }
+  }
+  return descendants;
+}
+
+// Kill a process and its whole descendant tree.
+// Returns { success, killed: [pids], failed: [pids], error? }.
+function killTree(pid) {
+  if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) {
+    return { success: false, killed: [], failed: [], error: 'Invalid PID' };
+  }
+
+  if (process.platform === 'win32') {
+    // taskkill /T terminates the entire tree in one call.
+    try {
+      const stdout = execSync(`taskkill /PID ${pid} /T /F`, {
+        encoding: 'utf-8',
+        timeout: 10000,
+        windowsHide: true,
+      });
+      // taskkill prints one "SUCCESS: ... PID <n> ..." line per process it
+      // terminated — parse them so the caller can report a real count.
+      // (On localized Windows the marker may not match; fall back to the root.)
+      const killed = [];
+      for (const m of stdout.matchAll(/SUCCESS[^\r\n]*?\bPID (\d+)/gi)) {
+        killed.push(parseInt(m[1], 10));
+      }
+      if (killed.length === 0) killed.push(pid);
+      return { success: true, killed, failed: [] };
+    } catch (err) {
+      return { success: false, killed: [], failed: [pid], error: classifyKillError(err) };
+    }
+  }
+
+  // Unix: discover descendants via ps, then kill leaves-first so children
+  // never get a chance to be reparented mid-teardown, root last.
+  let childrenOf;
+  try {
+    const psOutput = execSync('ps -eo pid,ppid', {
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    childrenOf = buildChildMap(psOutput);
+  } catch (err) {
+    return { success: false, killed: [], failed: [], error: err.message || 'Failed to list processes' };
+  }
+
+  const descendants = collectDescendants(pid, childrenOf);
+  const order = [...descendants].reverse(); // deepest first
+  order.push(pid); // root last
+
+  const killed = [];
+  const failed = [];
+  let firstError;
+  for (const target of order) {
+    const result = kill(target);
+    if (result.success) {
+      killed.push(target);
+    } else if (result.error === 'Process no longer exists') {
+      // Already gone (e.g. died with its parent) — treat as killed.
+      killed.push(target);
+    } else {
+      failed.push(target);
+      if (!firstError) firstError = result.error;
+    }
+  }
+
+  return {
+    success: failed.length === 0,
+    killed,
+    failed,
+    ...(firstError ? { error: firstError } : {}),
+  };
+}
+
+module.exports = { kill, killMultiple, killTree, buildChildMap, collectDescendants };

--- a/renderer/js/components/context-menu.js
+++ b/renderer/js/components/context-menu.js
@@ -67,6 +67,33 @@ function showContextMenu(x, y, proc) {
       className: 'context-item-danger',
       action: () => showKillConfirm(proc.pid, proc.name),
     },
+    {
+      label: 'Kill Tree',
+      icon: '\u00D7',
+      className: 'context-item-danger',
+      // Killing a whole tree is more destructive than a single kill, so it
+      // goes through the guarded confirm modal rather than straight to a kill.
+      action: () => {
+        showBatchKillConfirm(
+          `Kill ${proc.name} (PID ${proc.pid}) and all of its child processes?`,
+          [proc],
+          async () => {
+            const result = await window.api.killProcessTree(proc.pid);
+            const killedCount = (result.killed || []).length;
+            const failedCount = (result.failed || []).length;
+            if (result.success) {
+              showToast(`Killed ${killedCount} process(es) in the ${proc.name} tree`, { type: 'success' });
+            } else if (killedCount > 0) {
+              showError(`Killed ${killedCount} process(es), but ${failedCount} could not be killed: ${result.error || 'unknown error'}`);
+            } else {
+              showError(result.error || 'Failed to kill process tree');
+            }
+            // Reporting handled above; keep the batch handler quiet.
+            return { success: true };
+          }
+        );
+      },
+    },
     { separator: true },
     {
       label: isPinned ? 'Unpin' : 'Pin to top',

--- a/renderer/js/components/process-table.js
+++ b/renderer/js/components/process-table.js
@@ -214,6 +214,12 @@ function populateRow(tr, proc, opts = {}) {
 
   tr.className = 'proc-row';
   if (opts.isClusterChild) tr.classList.add('cluster-child');
+  if (opts.treeDepth) {
+    tr.classList.add('tree-child');
+    tr.style.setProperty('--tree-depth', opts.treeDepth);
+  } else {
+    tr.style.removeProperty('--tree-depth');
+  }
   if (isExpanded) tr.classList.add('expanded-row');
   if (isPinned) tr.classList.add('pinned-row');
   if (proc.hasWarning) tr.classList.add('warning-row');
@@ -221,10 +227,19 @@ function populateRow(tr, proc, opts = {}) {
   const nameChildren = [
     h('span', { className: `expand-indicator ${isExpanded ? 'open' : ''}` }, '▶'),
   ];
+  if (opts.treeDepth) {
+    nameChildren.push(h('span', { className: 'tree-branch' }, '└'));
+  }
   if (isPinned) {
     nameChildren.push(h('span', { className: 'pin-indicator', title: 'Pinned' }, '★'));
   }
   nameChildren.push(h('span', {}, proc.name));
+  if (proc.isOrphan) {
+    nameChildren.push(h('span', {
+      className: 'orphan-badge',
+      title: 'Orphaned: its parent process is gone',
+    }, 'orphan'));
+  }
 
   const cpuCell = h('td', {
     className: `col-cpu ${cpuClass(proc.cpu)}`,
@@ -373,7 +388,49 @@ function buildGroupRowItems(group, groupKey) {
   };
 
   if (!AppState.clusterMode) {
-    for (const proc of procs) pushProcess(proc);
+    // Tree view: indent processes under their in-group parent. Falls back to
+    // the flat list naturally when ppid data is absent (every proc is a root).
+    // Only build the tree under the default CPU sort — nesting reorders rows,
+    // which would silently defeat any sort column the user chose explicitly.
+    if (AppState.sortColumn !== 'cpu') {
+      for (const proc of procs) pushProcess(proc);
+      return items;
+    }
+
+    const pidsInGroup = new Set(procs.map((p) => p.pid));
+    const childrenOf = new Map(); // ppid -> [procs]
+    const roots = [];
+
+    for (const proc of procs) {
+      // Pinned processes always render as roots at the top of the group
+      // (where the sort put them) — pin placement wins over tree nesting.
+      const hasParentInGroup =
+        proc.ppid && proc.ppid !== proc.pid && pidsInGroup.has(proc.ppid) &&
+        !AppState.isPinned(proc.name);
+      if (hasParentInGroup) {
+        if (!childrenOf.has(proc.ppid)) childrenOf.set(proc.ppid, []);
+        childrenOf.get(proc.ppid).push(proc);
+      } else {
+        roots.push(proc);
+      }
+    }
+
+    const visited = new Set();
+    const emit = (proc, depth) => {
+      if (visited.has(proc.pid)) return;
+      visited.add(proc.pid);
+      pushProcess(proc, depth > 0 ? { treeDepth: depth } : undefined);
+      const kids = childrenOf.get(proc.pid);
+      if (kids) {
+        for (const kid of kids) emit(kid, depth + 1);
+      }
+    };
+
+    for (const proc of roots) emit(proc, 0);
+    // Safety net: pid cycles unreachable from any root still get rendered.
+    for (const proc of procs) {
+      if (!visited.has(proc.pid)) emit(proc, 0);
+    }
     return items;
   }
 

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -2079,4 +2079,29 @@
 .settings-user-rules .settings-threshold-input.input-error {
   border-color: var(--accent-red);
   animation: shake 0.3s ease;
+/* ── Process tree & orphans ─────────── */
+.tree-child .col-name {
+  padding-left: calc(8px + var(--tree-depth, 1) * 18px);
+  color: var(--text-secondary);
+}
+
+.tree-branch {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-right: 2px;
+  user-select: none;
+}
+
+.orphan-badge {
+  display: inline-block;
+  margin-left: 8px;
+  background: var(--accent-amber);
+  color: var(--bg-primary);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 0 6px;
+  border-radius: 8px;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }

--- a/test/anomaly-detector.test.js
+++ b/test/anomaly-detector.test.js
@@ -1,6 +1,6 @@
 const { test, beforeEach } = require('node:test');
 const assert = require('node:assert');
-const { detect, detectThresholds, detectDuplicates } = require('../main/services/anomaly-detector');
+const { detect, detectThresholds, detectDuplicates, detectOrphans } = require('../main/services/anomaly-detector');
 
 // detectThresholds keeps per-PID state between calls; passing zeroed
 // thresholds clears it so each test starts fresh.
@@ -105,4 +105,69 @@ test('detectDuplicates is disabled for thresholds below 2', () => {
   ];
   assert.deepStrictEqual(detectDuplicates(procs, { duplicateThreshold: 0 }), []);
   assert.deepStrictEqual(detectDuplicates(procs, { duplicateThreshold: 1 }), []);
+});
+
+test('detectOrphans (win32) flags dev processes whose parent pid is gone', () => {
+  const procs = [
+    { pid: 4, name: 'System', ppid: 0, group: 'system' },
+    { pid: 100, name: 'node.exe', ppid: 4, group: 'dev' },
+    { pid: 200, name: 'vite.exe', ppid: 9999, group: 'dev' }, // parent gone
+  ];
+  const warnings = detectOrphans(procs, 'win32');
+  assert.strictEqual(warnings.length, 1);
+  assert.strictEqual(warnings[0].pid, 200);
+  assert.strictEqual(warnings[0].key, 'orphan:200');
+  assert.strictEqual(warnings[0].processName, 'vite.exe');
+  assert.match(warnings[0].message, /orphaned/i);
+  assert.match(warnings[0].message, /9999/);
+});
+
+test('detectOrphans (linux) flags dev processes reparented to init', () => {
+  // Unix reparents orphans to pid 1 immediately, so a missing ppid is never
+  // observable — adoption by init is the orphan signal instead.
+  const procs = [
+    { pid: 1, name: 'systemd', ppid: 0, group: 'system' },
+    { pid: 100, name: 'bash', ppid: 1, group: 'system' },
+    { pid: 200, name: 'node', ppid: 100, group: 'dev' }, // parent alive
+    { pid: 300, name: 'vite', ppid: 1, group: 'dev' },   // adopted by init
+  ];
+  const warnings = detectOrphans(procs, 'linux');
+  assert.strictEqual(warnings.length, 1);
+  assert.strictEqual(warnings[0].pid, 300);
+  assert.strictEqual(warnings[0].key, 'orphan:300');
+  assert.match(warnings[0].message, /orphaned/i);
+});
+
+test('detectOrphans ignores non-dev groups on both platforms', () => {
+  const procs = [
+    { pid: 1, name: 'systemd', ppid: 0, group: 'system' },
+    { pid: 300, name: 'svchost.exe', ppid: 9999, group: 'system' },
+    { pid: 301, name: 'chrome.exe', ppid: 1, group: 'apps' },
+  ];
+  assert.deepStrictEqual(detectOrphans(procs, 'win32'), []);
+  assert.deepStrictEqual(detectOrphans(procs, 'linux'), []);
+});
+
+test('detectOrphans treats missing or zero ppid as unknown, not orphaned', () => {
+  const procs = [
+    { pid: 400, name: 'node.exe', ppid: 0, group: 'dev' },
+    { pid: 401, name: 'node.exe', group: 'dev' },
+  ];
+  assert.deepStrictEqual(detectOrphans(procs, 'win32'), []);
+  assert.deepStrictEqual(detectOrphans(procs, 'linux'), []);
+});
+
+test('detectOrphans stays quiet when the parent chain is present', () => {
+  const procs = [
+    { pid: 500, name: 'npm.exe', ppid: 0, group: 'dev' },
+    { pid: 501, name: 'node.exe', ppid: 500, group: 'dev' },
+    { pid: 502, name: 'esbuild.exe', ppid: 501, group: 'dev' },
+  ];
+  assert.deepStrictEqual(detectOrphans(procs, 'win32'), []);
+  assert.deepStrictEqual(detectOrphans(procs, 'linux'), []);
+});
+
+test('detectOrphans returns empty for an empty process list', () => {
+  assert.deepStrictEqual(detectOrphans([], 'win32'), []);
+  assert.deepStrictEqual(detectOrphans([], 'linux'), []);
 });

--- a/test/process-collector.test.js
+++ b/test/process-collector.test.js
@@ -1,6 +1,11 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { parseTasklistCSV, parsePsOutput } = require('../main/collectors/process-collector');
+const {
+  parseTasklistCSV,
+  parsePsOutput,
+  parseCimPpidCsv,
+  parseWmicPpidOutput,
+} = require('../main/collectors/process-collector');
 
 test('parseTasklistCSV parses tasklist /FO CSV output', () => {
   const output = [
@@ -33,11 +38,11 @@ test('parseTasklistCSV returns empty array for empty output', () => {
   assert.deepStrictEqual(parseTasklistCSV(''), []);
 });
 
-test('parsePsOutput parses ps pid/rss/comm output', () => {
+test('parsePsOutput parses ps pid/ppid/rss/comm output', () => {
   const output = [
-    '  PID   RSS COMMAND',
-    ' 1234 51200 node',
-    ' 2200 90000 /usr/lib/postgresql/16/bin/postgres',
+    '  PID  PPID   RSS COMMAND',
+    ' 1234     1 51200 node',
+    ' 2200  1234 90000 /usr/lib/postgresql/16/bin/postgres',
     'garbage',
   ].join('\n');
 
@@ -46,11 +51,72 @@ test('parsePsOutput parses ps pid/rss/comm output', () => {
   assert.strictEqual(processes.length, 2);
   assert.deepStrictEqual(processes[0], {
     pid: 1234,
+    ppid: 1,
     name: 'node',
     memKB: 51200,
     status: 'Running',
   });
   // Name is extracted from the command path
   assert.strictEqual(processes[1].name, 'postgres');
+  assert.strictEqual(processes[1].ppid, 1234);
   assert.strictEqual(processes[1].memKB, 90000);
+});
+
+test('parseCimPpidCsv parses ConvertTo-Csv ProcessId/ParentProcessId output', () => {
+  const output = [
+    '"ProcessId","ParentProcessId"',
+    '"0","0"',
+    '"4","0"',
+    '"12345","6512"',
+    '"9440","12345"',
+    'garbage line',
+  ].join('\r\n');
+
+  const map = parseCimPpidCsv(output);
+
+  assert.strictEqual(map.get(12345), 6512);
+  assert.strictEqual(map.get(9440), 12345);
+  assert.strictEqual(map.get(4), 0);
+  // Header line contributes nothing
+  assert.strictEqual(map.size, 4);
+});
+
+test('parseCimPpidCsv returns empty map for empty output', () => {
+  assert.strictEqual(parseCimPpidCsv('').size, 0);
+});
+
+test('parseWmicPpidOutput parses wmic column output using the header order', () => {
+  // wmic sorts columns alphabetically: ParentProcessId comes first
+  const output = [
+    'ParentProcessId  ProcessId',
+    '0                0',
+    '6512             12345',
+    '12345            9440',
+    '',
+  ].join('\r\n');
+
+  const map = parseWmicPpidOutput(output);
+
+  assert.strictEqual(map.get(12345), 6512);
+  assert.strictEqual(map.get(9440), 12345);
+  assert.strictEqual(map.size, 3);
+});
+
+test('parseWmicPpidOutput keeps rows with a blank ParentProcessId as ppid 0', () => {
+  const output = [
+    'ParentProcessId  ProcessId',
+    '                 4',
+    '6512             12345',
+  ].join('\r\n');
+
+  const map = parseWmicPpidOutput(output);
+
+  assert.strictEqual(map.get(4), 0);
+  assert.strictEqual(map.get(12345), 6512);
+  assert.strictEqual(map.size, 2);
+});
+
+test('parseWmicPpidOutput returns empty map when the header is missing', () => {
+  assert.strictEqual(parseWmicPpidOutput('').size, 0);
+  assert.strictEqual(parseWmicPpidOutput('1234 5678').size, 0);
 });


### PR DESCRIPTION
## Summary
- Collect `ppid` for every process on all platforms: `ps -eo pid,ppid,rss,comm` on linux/darwin; on win32 the `tasklist` snapshot is joined with one parallel PowerShell `Get-CimInstance Win32_Process` pid/ppid query (with a `wmic` fallback for systems predating its removal in Win11 24H2).
- **Orphan detection** (`detectOrphans`, dev group only): on win32 a stale/missing parent pid is the signal; on unix adoption by pid 1 is (the kernel reparents immediately). Orphans get a warning (`orphan:<pid>`, deduped by the notifier) and an amber "orphan" badge, with `proc.isOrphan` stamped in the poll merge like `hasWarning`.
- **Kill tree**: `killTree(pid)` uses `taskkill /PID <pid> /T /F` on win32 (parsing the per-pid SUCCESS lines for a real count) and a `ps`-derived child map with leaves-first kills on unix; returns `{success, killed, failed, error?}` and shares error classification with `kill()`. Exposed via `kill-process-tree` IPC + `window.api.killProcessTree`, wired to a new "Kill Tree" context-menu entry behind the guarded confirm modal with a killed-count toast.
- **Tree view**: in non-cluster mode under the default CPU sort, child processes are indented beneath their in-group parent (stable `p:<pid>` reconciler keys, depth-based indent, cycle-safe). Pinned rows stay top-level, other sort columns keep today's flat sorted list, and missing ppid data degrades to the flat list.

## Testing
- `npm test` (41 passing) covers the new ps/CIM/wmic parsers (including blank-ppid tolerance) and `detectOrphans` on both platform modes; `npm run lint` clean.
- Live-verified on Windows: collector joins ppid for 750+ processes; `killTree` terminated a spawned cmd→ping tree (3 pids reported); 25 s smoke boot with no renderer/main errors.
